### PR TITLE
feat: add domain types for all entities

### DIFF
--- a/src/types/domain.test.ts
+++ b/src/types/domain.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { RecordType } from "./domain";
+import type { Conversation, Record, Attachment, Source } from "./domain";
+
+describe("RecordType", () => {
+  it("has all expected values", () => {
+    expect(RecordType.TEXT).toBe("text");
+    expect(RecordType.IMAGE).toBe("image");
+    expect(RecordType.VIDEO).toBe("video");
+    expect(RecordType.AUDIO).toBe("audio");
+  });
+
+  it("has exactly 4 types", () => {
+    const values = Object.values(RecordType);
+    expect(values).toHaveLength(4);
+  });
+});
+
+describe("domain types", () => {
+  it("allows valid Conversation", () => {
+    const conversation: Conversation = {
+      id: "conv-1",
+      userId: "user-1",
+      sourceId: null,
+      title: "テスト会話",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    };
+    expect(conversation.title).toBe("テスト会話");
+    expect(conversation.sourceId).toBeNull();
+  });
+
+  it("allows valid Record with text type", () => {
+    const record: Record = {
+      id: "rec-1",
+      conversationId: "conv-1",
+      recordType: RecordType.TEXT,
+      title: null,
+      content: "テスト内容",
+      hasAudio: false,
+      position: 0,
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    };
+    expect(record.recordType).toBe("text");
+    expect(record.content).toBe("テスト内容");
+  });
+
+  it("allows valid Source", () => {
+    const source: Source = {
+      id: "src-1",
+      userId: "user-1",
+      name: "LINE",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    };
+    expect(source.name).toBe("LINE");
+  });
+
+  it("allows valid Attachment", () => {
+    const attachment: Attachment = {
+      id: "att-1",
+      recordId: "rec-1",
+      filePath: "user-1/conv-1/rec-1/image.png",
+      mimeType: "image/png",
+      fileSize: 1024,
+      createdAt: "2026-01-01T00:00:00Z",
+    };
+    expect(attachment.mimeType).toBe("image/png");
+  });
+});

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -1,0 +1,58 @@
+/** トーク種別 */
+export const RecordType = {
+  TEXT: "text",
+  IMAGE: "image",
+  VIDEO: "video",
+  AUDIO: "audio",
+} as const;
+
+export type RecordType = (typeof RecordType)[keyof typeof RecordType];
+
+/** ユーザー */
+export type User = {
+  id: string;
+  email: string;
+  createdAt: string;
+};
+
+/** トークの出所 */
+export type Source = {
+  id: string;
+  userId: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+/** 会話 */
+export type Conversation = {
+  id: string;
+  userId: string;
+  sourceId: string | null;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+/** トークレコード */
+export type Record = {
+  id: string;
+  conversationId: string;
+  recordType: RecordType;
+  title: string | null;
+  content: string | null;
+  hasAudio: boolean;
+  position: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+/** 添付ファイルメタデータ */
+export type Attachment = {
+  id: string;
+  recordId: string;
+  filePath: string;
+  mimeType: string;
+  fileSize: number;
+  createdAt: string;
+};


### PR DESCRIPTION
## Summary

- `src/types/domain.ts` にドメイン型を定義
  - `RecordType` const object（text, image, video, audio）
  - `User`, `Source`, `Conversation`, `Record`, `Attachment` 型
- 純粋な型のみ（ランタイム依存なし、`any` 不使用）
- テスト 6 件追加（RecordType 値の検証、各型の形状検証）

## Test plan

- [ ] `pnpm test` — 全テスト通過
- [ ] `pnpm typecheck` — 型エラーなし
- [ ] 型が `docs/database.md` のテーブル設計と整合していること

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)