### PR TITLE
feat: add initial database migration and schema ADR

### DIFF
--- a/docs/decisions/002-database-schema.md
+++ b/docs/decisions/002-database-schema.md
@@ -43,6 +43,7 @@ docs/database.md で定義された5テーブル（users, sources, conversations
 - **users テーブルは作成しない。** `auth.users` を直接参照する。単一ユーザーアプリのため、プロフィール拡張の必要性が低い。将来必要になれば `profiles` テーブルを追加する。
 - **pg_trgm + GIN インデックス** を採用。Supabase Cloud で利用可能で、日本語の部分一致検索に十分対応できる。
 - **RLS** を全テーブルに設定し、`auth.uid()` でユーザーを制限する。records と attachments は親テーブル経由で所有者を判定する。
+- conversations は **同一ユーザーが所有する source のみ参照可能** とし、records は **text レコードで content を必須** にする。
 - **updated_at** の自動更新トリガーを設定する。
 
 ## Consequences
@@ -50,3 +51,4 @@ docs/database.md で定義された5テーブル（users, sources, conversations
 - users テーブルが無いため、ユーザープロフィール情報の保存には別途テーブル追加が必要
 - pg_trgm は形態素解析ではないため、日本語の検索精度に限界がある（データ量増加時に外部検索サービスを検討）
 - records/attachments の RLS は EXISTS サブクエリを使うため、大量データ時にパフォーマンスへの影響を確認する必要がある
+- 制約を DB に寄せたため、UseCase/Repository 層は不正データを前提にした防御を減らせる一方、将来仕様変更時はマイグレーション更新が必要

--- a/supabase/migrations/20260310000000_initial_schema.sql
+++ b/supabase/migrations/20260310000000_initial_schema.sql
@@ -33,7 +33,10 @@ create table records (
   has_audio boolean not null default false,
   position integer not null default 0,
   created_at timestamptz not null default now(),
-  updated_at timestamptz not null default now()
+  updated_at timestamptz not null default now(),
+  constraint records_text_content_check check (
+    record_type <> 'text' or content is not null
+  )
 );
 
 -- Attachments: media file metadata
@@ -72,7 +75,17 @@ create policy "Users can manage their own sources"
 create policy "Users can manage their own conversations"
   on conversations for all
   using (auth.uid() = user_id)
-  with check (auth.uid() = user_id);
+  with check (
+    auth.uid() = user_id
+    and (
+      source_id is null
+      or exists (
+        select 1 from sources
+        where sources.id = conversations.source_id
+          and sources.user_id = auth.uid()
+      )
+    )
+  );
 
 create policy "Users can manage records in their conversations"
   on records for all


### PR DESCRIPTION
## Summary

初期 DB スキーマのマイグレーションと設計判断の ADR を追加。

### マイグレーション (`supabase/migrations/20260310000000_initial_schema.sql`)
- `record_type` enum（text, image, video, audio）
- `sources` — トークの出所管理
- `conversations` — 会話グループ（source への FK あり）
- `records` — 個別トークエントリ（conversation への FK、position で順序管理）
- `attachments` — メディアファイルメタデータ（record への FK）
- 全テーブルに RLS ポリシー（`auth.uid()` で制限、子テーブルは EXISTS サブクエリ）
- `pg_trgm` GIN インデックス（`records.content` に日本語部分一致検索用）
- `updated_at` 自動更新トリガー
- FK カラムへのインデックス

### ADR (`docs/decisions/002-database-schema.md`)
- `users` テーブルは作成せず `auth.users` を直接参照（単一ユーザーのため）
- 日本語検索は `pg_trgm` を採用（Supabase Cloud 互換）

## Test plan

- [ ] CI が通ること
- [ ] Supabase ダッシュボードまたは CLI でマイグレーションを適用し、テーブルが作成されること
- [ ] RLS が有効で、認証ユーザーのみデータにアクセスできること
- [ ] `src/types/domain.ts` のドメイン型とカラム構成が整合していること

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)