### PR TITLE
feat: add Attachment repository with CRUD and type filtering

### DIFF
--- a/src/repositories/attachmentRepository.test.ts
+++ b/src/repositories/attachmentRepository.test.ts
@@ -9,6 +9,15 @@ import {
 } from "./attachmentRepository";
 
 type AttachmentRow = Database["public"]["Tables"]["attachments"]["Row"];
+type AttachmentWithRecordRow = AttachmentRow & {
+  records: {
+    conversation_id: string;
+    record_type: "text" | "image" | "video" | "audio";
+    conversations: {
+      user_id: string;
+    };
+  };
+};
 
 const baseRow: AttachmentRow = {
   id: "att-1",
@@ -98,10 +107,20 @@ describe("attachmentRepository", () => {
 
   describe("getAttachmentsByType", () => {
     it("returns attachments filtered by record type and user", async () => {
+      const mediaRow: AttachmentWithRecordRow = {
+        ...baseRow,
+        records: {
+          conversation_id: "conv-1",
+          record_type: "image",
+          conversations: {
+            user_id: "user-1",
+          },
+        },
+      };
       builder = createMockQueryBuilder({
         order: vi
           .fn()
-          .mockResolvedValue({ data: [baseRow], error: null }),
+          .mockResolvedValue({ data: [mediaRow], error: null }),
       });
       client = createMockClient(builder);
 
@@ -109,8 +128,9 @@ describe("attachmentRepository", () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe("att-1");
+      expect(result[0].conversationId).toBe("conv-1");
       expect(builder.select).toHaveBeenCalledWith(
-        "*, records!inner(record_type, conversations!inner(user_id))",
+        "*, records!inner(conversation_id, record_type, conversations!inner(user_id))",
       );
       expect(builder.eq).toHaveBeenCalledWith(
         "records.conversations.user_id",

--- a/src/repositories/attachmentRepository.ts
+++ b/src/repositories/attachmentRepository.ts
@@ -1,8 +1,15 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/types/database";
-import type { Attachment, RecordType } from "@/types/domain";
+import type { Attachment, MediaAttachment, RecordType } from "@/types/domain";
 
 type AttachmentRow = Database["public"]["Tables"]["attachments"]["Row"];
+type RecordRow = Database["public"]["Tables"]["records"]["Row"];
+type ConversationRow = Database["public"]["Tables"]["conversations"]["Row"];
+type AttachmentWithRecordRow = AttachmentRow & {
+  records: Pick<RecordRow, "conversation_id" | "record_type"> & {
+    conversations: Pick<ConversationRow, "user_id">;
+  };
+};
 
 function toAttachment(row: AttachmentRow): Attachment {
   return {
@@ -12,6 +19,13 @@ function toAttachment(row: AttachmentRow): Attachment {
     mimeType: row.mime_type,
     fileSize: row.file_size,
     createdAt: row.created_at,
+  };
+}
+
+function toMediaAttachment(row: AttachmentWithRecordRow): MediaAttachment {
+  return {
+    ...toAttachment(row),
+    conversationId: row.records.conversation_id,
   };
 }
 
@@ -37,11 +51,11 @@ export async function getAttachmentsByType(
   userId: string,
   recordType: RecordType,
   options?: { limit?: number; offset?: number },
-): Promise<Attachment[]> {
+): Promise<MediaAttachment[]> {
   let query = client
     .from("attachments")
     .select(
-      "*, records!inner(record_type, conversations!inner(user_id))",
+      "*, records!inner(conversation_id, record_type, conversations!inner(user_id))",
     )
     .eq("records.conversations.user_id", userId)
     .eq("records.record_type", recordType)
@@ -63,7 +77,7 @@ export async function getAttachmentsByType(
     throw error;
   }
 
-  return data.map((row) => toAttachment(row as unknown as AttachmentRow));
+  return data.map((row) => toMediaAttachment(row as AttachmentWithRecordRow));
 }
 
 export async function createAttachment(

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -56,3 +56,8 @@ export type Attachment = {
   fileSize: number;
   createdAt: string;
 };
+
+/** メディア一覧表示用の添付ファイル */
+export type MediaAttachment = Attachment & {
+  conversationId: string;
+};


### PR DESCRIPTION
## Summary

- `src/repositories/attachmentRepository.ts` を作成
- 4関数: `getAttachmentsByRecord`, `getAttachmentsByType`, `createAttachment`, `deleteAttachment`
- `getAttachmentsByType` は `records!inner` + `conversations!inner` JOIN で所有者フィルタリング + メディア種別フィルタ、`limit`/`offset` によるページネーション対応
- メタデータのみ管理（ファイルアップロードは Phase 3 の Storage サービスで対応）
- 10件のユニットテスト

## Test plan

- [x] `pnpm test` — 全71テスト pass（新規10テスト）
- [x] `pnpm typecheck` — pass
- [x] `pnpm lint` — pass

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)