### PR TITLE
feat: add conversation detail page with record timeline

### DIFF
--- a/src/app/(app)/conversations/[id]/not-found.tsx
+++ b/src/app/(app)/conversations/[id]/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+
+export default function ConversationNotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center py-20">
+      <h1 className="text-2xl font-bold">会話が見つかりません</h1>
+      <p className="mt-2 text-sm text-gray-500">
+        指定された会話は存在しないか、削除された可能性があります。
+      </p>
+      <Link
+        href="/"
+        className="mt-6 rounded bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+      >
+        会話一覧に戻る
+      </Link>
+    </div>
+  );
+}

--- a/src/app/(app)/conversations/[id]/page.tsx
+++ b/src/app/(app)/conversations/[id]/page.tsx
@@ -1,10 +1,39 @@
-export default function ConversationDetailPage() {
+import { notFound, redirect } from "next/navigation";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { getConversationWithRecords } from "@/usecases/conversationUseCases";
+import { ConversationHeader } from "@/components/ConversationHeader";
+import { RecordTimeline } from "@/components/RecordTimeline";
+
+type ConversationDetailPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function ConversationDetailPage({
+  params,
+}: ConversationDetailPageProps) {
+  const { id } = await params;
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const conversation = await getConversationWithRecords(supabase, id);
+
+  if (!conversation) {
+    notFound();
+  }
+
   return (
-    <div>
-      <h1 className="text-2xl font-bold">会話詳細</h1>
-      <p className="mt-2 text-sm text-gray-500">
-        会話詳細画面はまだ実装中です。
-      </p>
+    <div className="mx-auto max-w-3xl">
+      <ConversationHeader conversation={conversation} />
+      <div className="mt-6">
+        <RecordTimeline records={conversation.records} />
+      </div>
     </div>
   );
 }

--- a/src/components/ConversationHeader.test.tsx
+++ b/src/components/ConversationHeader.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ConversationHeader } from "./ConversationHeader";
+import type { ConversationWithMetadata } from "@/usecases/conversationUseCases";
+
+const baseConversation: ConversationWithMetadata = {
+  id: "conv-1",
+  userId: "user-1",
+  sourceId: null,
+  idolGroup: "nogizaka",
+  coverImagePath: null,
+  title: "テスト会話",
+  createdAt: "2026-01-15T00:00:00Z",
+  updatedAt: "2026-01-20T00:00:00Z",
+  activePeriods: [
+    {
+      id: "period-1",
+      conversationId: "conv-1",
+      startDate: "2026-01-01",
+      endDate: "2026-06-30",
+      createdAt: "2026-01-15T00:00:00Z",
+    },
+  ],
+  participants: [
+    {
+      id: "part-1",
+      conversationId: "conv-1",
+      name: "メンバーA",
+      sortOrder: 0,
+      createdAt: "2026-01-15T00:00:00Z",
+    },
+  ],
+  activeDays: 181,
+};
+
+describe("ConversationHeader", () => {
+  it("renders conversation title", () => {
+    render(<ConversationHeader conversation={baseConversation} />);
+
+    expect(screen.getByText("テスト会話")).toBeInTheDocument();
+  });
+
+  it("renders idol group label", () => {
+    render(<ConversationHeader conversation={baseConversation} />);
+
+    expect(screen.getByText("乃木坂46")).toBeInTheDocument();
+  });
+
+  it("renders participant names", () => {
+    render(<ConversationHeader conversation={baseConversation} />);
+
+    expect(screen.getByText("メンバーA")).toBeInTheDocument();
+  });
+
+  it("renders multiple participant names joined", () => {
+    const conversation: ConversationWithMetadata = {
+      ...baseConversation,
+      participants: [
+        { ...baseConversation.participants[0], name: "メンバーA" },
+        {
+          id: "part-2",
+          conversationId: "conv-1",
+          name: "メンバーB",
+          sortOrder: 1,
+          createdAt: "2026-01-15T00:00:00Z",
+        },
+      ],
+    };
+    render(<ConversationHeader conversation={conversation} />);
+
+    expect(screen.getByText("メンバーA、メンバーB")).toBeInTheDocument();
+  });
+
+  it("renders active days", () => {
+    render(<ConversationHeader conversation={baseConversation} />);
+
+    expect(screen.getByText("181日")).toBeInTheDocument();
+  });
+
+  it("renders active period with end date", () => {
+    render(<ConversationHeader conversation={baseConversation} />);
+
+    expect(
+      screen.getByText("2026-01-01 〜 2026-06-30"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders ongoing period", () => {
+    const conversation: ConversationWithMetadata = {
+      ...baseConversation,
+      activePeriods: [
+        { ...baseConversation.activePeriods[0], endDate: null },
+      ],
+    };
+    render(<ConversationHeader conversation={conversation} />);
+
+    expect(screen.getByText("2026-01-01 〜 継続中")).toBeInTheDocument();
+  });
+
+  it("renders creation date", () => {
+    render(<ConversationHeader conversation={baseConversation} />);
+
+    expect(screen.getByText("2026/01/15")).toBeInTheDocument();
+  });
+});

--- a/src/components/ConversationHeader.tsx
+++ b/src/components/ConversationHeader.tsx
@@ -1,0 +1,74 @@
+import type { ConversationWithMetadata } from "@/usecases/conversationUseCases";
+import type { IdolGroup } from "@/types/domain";
+
+type ConversationHeaderProps = {
+  conversation: ConversationWithMetadata;
+};
+
+const idolGroupLabels: Record<IdolGroup, string> = {
+  nogizaka: "乃木坂46",
+  sakurazaka: "櫻坂46",
+  hinatazaka: "日向坂46",
+};
+
+function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+}
+
+function formatPeriod(
+  startDate: string,
+  endDate: string | null,
+): string {
+  if (endDate) {
+    return `${startDate} 〜 ${endDate}`;
+  }
+  return `${startDate} 〜 継続中`;
+}
+
+export function ConversationHeader({
+  conversation,
+}: ConversationHeaderProps) {
+  const participantNames = conversation.participants
+    .map((p) => p.name)
+    .join("、");
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold">{conversation.title}</h1>
+      <div className="mt-3 space-y-1 text-sm text-gray-600">
+        <p>
+          <span className="font-medium text-gray-700">グループ:</span>{" "}
+          {idolGroupLabels[conversation.idolGroup]}
+        </p>
+        {participantNames && (
+          <p>
+            <span className="font-medium text-gray-700">参加者:</span>{" "}
+            {participantNames}
+          </p>
+        )}
+        <p>
+          <span className="font-medium text-gray-700">会話期間:</span>{" "}
+          {conversation.activeDays}日
+        </p>
+        {conversation.activePeriods.length > 0 && (
+          <ul className="ml-4 list-disc text-xs text-gray-500">
+            {conversation.activePeriods.map((period) => (
+              <li key={period.id}>
+                {formatPeriod(period.startDate, period.endDate)}
+              </li>
+            ))}
+          </ul>
+        )}
+        <p>
+          <span className="font-medium text-gray-700">作成日:</span>{" "}
+          {formatDate(conversation.createdAt)}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/RecordCard.test.tsx
+++ b/src/components/RecordCard.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RecordCard } from "./RecordCard";
+import type { Record } from "@/types/domain";
+
+const baseRecord: Record = {
+  id: "rec-1",
+  conversationId: "conv-1",
+  recordType: "text",
+  title: "テストタイトル",
+  content: "テスト内容です",
+  hasAudio: false,
+  position: 0,
+  createdAt: "2026-01-15T10:30:00Z",
+  updatedAt: "2026-01-15T10:30:00Z",
+};
+
+describe("RecordCard", () => {
+  it("renders record type icon for text", () => {
+    render(<RecordCard record={baseRecord} />);
+
+    expect(screen.getByText("T")).toBeInTheDocument();
+  });
+
+  it("renders record type icon for image", () => {
+    render(
+      <RecordCard record={{ ...baseRecord, recordType: "image" }} />,
+    );
+
+    expect(screen.getByText("I")).toBeInTheDocument();
+  });
+
+  it("renders record type icon for video", () => {
+    render(
+      <RecordCard record={{ ...baseRecord, recordType: "video" }} />,
+    );
+
+    expect(screen.getByText("V")).toBeInTheDocument();
+  });
+
+  it("renders record type icon for audio", () => {
+    render(
+      <RecordCard record={{ ...baseRecord, recordType: "audio" }} />,
+    );
+
+    expect(screen.getByText("A")).toBeInTheDocument();
+  });
+
+  it("renders title when present", () => {
+    render(<RecordCard record={baseRecord} />);
+
+    expect(screen.getByText("テストタイトル")).toBeInTheDocument();
+  });
+
+  it("does not render title when null", () => {
+    render(<RecordCard record={{ ...baseRecord, title: null }} />);
+
+    expect(screen.queryByText("テストタイトル")).not.toBeInTheDocument();
+  });
+
+  it("renders content", () => {
+    render(<RecordCard record={baseRecord} />);
+
+    expect(screen.getByText("テスト内容です")).toBeInTheDocument();
+  });
+
+  it("does not render content when null", () => {
+    render(<RecordCard record={{ ...baseRecord, content: null }} />);
+
+    expect(screen.queryByText("テスト内容です")).not.toBeInTheDocument();
+  });
+
+  it("renders formatted timestamp", () => {
+    render(<RecordCard record={baseRecord} />);
+
+    // タイムスタンプが表示されることを確認（ロケール依存のため部分一致）
+    expect(screen.getByText(/2026/)).toBeInTheDocument();
+  });
+});

--- a/src/components/RecordCard.tsx
+++ b/src/components/RecordCard.tsx
@@ -1,0 +1,51 @@
+import type { Record, RecordType } from "@/types/domain";
+
+type RecordCardProps = {
+  record: Record;
+};
+
+const recordTypeLabels: { [K in RecordType]: { icon: string; label: string } } = {
+  text: { icon: "T", label: "テキスト" },
+  image: { icon: "I", label: "画像" },
+  video: { icon: "V", label: "動画" },
+  audio: { icon: "A", label: "音声" },
+};
+
+function formatTimestamp(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function RecordCard({ record }: RecordCardProps) {
+  const typeInfo = recordTypeLabels[record.recordType];
+
+  return (
+    <div className="rounded border border-gray-200 px-4 py-3">
+      <div className="flex items-center gap-2">
+        <span
+          className="flex h-6 w-6 items-center justify-center rounded bg-gray-100 text-xs font-bold text-gray-600"
+          title={typeInfo.label}
+        >
+          {typeInfo.icon}
+        </span>
+        {record.title && (
+          <span className="text-sm font-medium">{record.title}</span>
+        )}
+        <span className="ml-auto text-xs text-gray-400">
+          {formatTimestamp(record.createdAt)}
+        </span>
+      </div>
+      {record.content && (
+        <p className="mt-2 whitespace-pre-wrap text-sm text-gray-700">
+          {record.content}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/RecordTimeline.test.tsx
+++ b/src/components/RecordTimeline.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RecordTimeline } from "./RecordTimeline";
+import type { Record } from "@/types/domain";
+
+const baseRecord: Record = {
+  id: "rec-1",
+  conversationId: "conv-1",
+  recordType: "text",
+  title: "最初のトーク",
+  content: "こんにちは",
+  hasAudio: false,
+  position: 0,
+  createdAt: "2026-01-15T10:00:00Z",
+  updatedAt: "2026-01-15T10:00:00Z",
+};
+
+describe("RecordTimeline", () => {
+  it("renders empty state when no records", () => {
+    render(<RecordTimeline records={[]} />);
+
+    expect(
+      screen.getByText("トークレコードがまだありません。"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders records", () => {
+    const records = [
+      baseRecord,
+      {
+        ...baseRecord,
+        id: "rec-2",
+        title: "2番目のトーク",
+        content: "お元気ですか",
+        position: 1,
+      },
+    ];
+    render(<RecordTimeline records={records} />);
+
+    expect(screen.getByText("最初のトーク")).toBeInTheDocument();
+    expect(screen.getByText("こんにちは")).toBeInTheDocument();
+    expect(screen.getByText("2番目のトーク")).toBeInTheDocument();
+    expect(screen.getByText("お元気ですか")).toBeInTheDocument();
+  });
+});

--- a/src/components/RecordTimeline.tsx
+++ b/src/components/RecordTimeline.tsx
@@ -1,0 +1,24 @@
+import type { Record } from "@/types/domain";
+import { RecordCard } from "@/components/RecordCard";
+
+type RecordTimelineProps = {
+  records: Record[];
+};
+
+export function RecordTimeline({ records }: RecordTimelineProps) {
+  if (records.length === 0) {
+    return (
+      <p className="text-sm text-gray-500">
+        トークレコードがまだありません。
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {records.map((record) => (
+        <RecordCard key={record.id} record={record} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- `/conversations/[id]` ルートに会話詳細ページを実装
- `ConversationHeader`: タイトル、グループ（乃木坂/櫻坂/日向坂）、参加者、会話期間・活動日数、作成日を表示
- `RecordTimeline` + `RecordCard`: レコードを時系列で表示（種別アイコン、タイトル、内容、タイムスタンプ）
- `not-found.tsx`: 存在しない会話IDの404ハンドリング

### 作成ファイル
| ファイル | 役割 |
|---------|------|
| `src/app/(app)/conversations/[id]/page.tsx` | Server Component（認証 + データ取得 + 404） |
| `src/app/(app)/conversations/[id]/not-found.tsx` | 404ページ |
| `src/components/ConversationHeader.tsx` | 会話メタデータ表示 |
| `src/components/RecordTimeline.tsx` | レコード一覧（空状態対応） |
| `src/components/RecordCard.tsx` | 個別レコード表示 |

Closes #18

## Test plan

- [x] `pnpm lint` — エラーなし
- [x] `pnpm typecheck` — 型エラーなし
- [x] `pnpm test` — 全187テスト通過（新規19テスト含む）
- [x] `pnpm build` — ビルド成功
- [ ] `/conversations/[id]` にアクセスして会話詳細が表示されることを確認
- [ ] 存在しないIDで404が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)