### PR TITLE
feat: add video record upload form

### DIFF
--- a/src/app/(app)/conversations/[id]/actions.test.ts
+++ b/src/app/(app)/conversations/[id]/actions.test.ts
@@ -16,6 +16,7 @@ const revalidatePathMock = vi.fn();
 const validateAddTextRecordInputMock = vi.fn();
 const addTextRecordMock = vi.fn();
 const addImageRecordMock = vi.fn();
+const addVideoRecordMock = vi.fn();
 const validateAddMediaRecordInputMock = vi.fn();
 const validateUpdateConversationInputMock = vi.fn();
 const updateExistingConversationMock = vi.fn();
@@ -46,6 +47,7 @@ vi.mock("@/usecases/recordUseCases", () => ({
   validateAddTextRecordInput: validateAddTextRecordInputMock,
   addTextRecord: addTextRecordMock,
   addImageRecord: addImageRecordMock,
+  addVideoRecord: addVideoRecordMock,
   validateAddMediaRecordInput: validateAddMediaRecordInputMock,
   validateUpdateRecordInput: validateUpdateRecordInputMock,
   updateExistingRecord: updateExistingRecordMock,
@@ -591,6 +593,139 @@ describe("addImageRecordAction", () => {
         title: null,
         content: null,
       }),
+    );
+  });
+});
+
+function createVideoFormData(overrides?: {
+  file?: File;
+  title?: string;
+  hasAudio?: string;
+}): FormData {
+  const formData = new FormData();
+  const file =
+    overrides?.file ??
+    new File(["video-data"], "clip.mp4", { type: "video/mp4" });
+  formData.set("file", file);
+  if (overrides?.title !== undefined) {
+    formData.set("title", overrides.title);
+  }
+  if (overrides?.hasAudio !== undefined) {
+    formData.set("hasAudio", overrides.hasAudio);
+  }
+  return formData;
+}
+
+describe("addVideoRecordAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("redirects to login when not authenticated", async () => {
+    mockSupabaseClient(null);
+
+    const { addVideoRecordAction } = await import("./actions");
+    await expect(
+      addVideoRecordAction("conv-1", undefined, createVideoFormData()),
+    ).rejects.toThrow("NEXT_REDIRECT: /login");
+  });
+
+  it("returns error when file is missing", async () => {
+    mockSupabaseClient({ id: "user-1" });
+
+    const { addVideoRecordAction } = await import("./actions");
+    const result = await addVideoRecordAction(
+      "conv-1",
+      undefined,
+      new FormData(),
+    );
+
+    expect(result).toEqual({ error: "動画ファイルを選択してください" });
+    expect(addVideoRecordMock).not.toHaveBeenCalled();
+  });
+
+  it("returns error when file exceeds 50MB", async () => {
+    mockSupabaseClient({ id: "user-1" });
+
+    const { addVideoRecordAction } = await import("./actions");
+    const largeFile = new File(
+      [new ArrayBuffer(50 * 1024 * 1024 + 1)],
+      "large.mp4",
+      { type: "video/mp4" },
+    );
+    const result = await addVideoRecordAction(
+      "conv-1",
+      undefined,
+      createVideoFormData({ file: largeFile }),
+    );
+
+    expect(result).toEqual({
+      error: "ファイルサイズは50MB以内にしてください",
+    });
+  });
+
+  it("returns error when file is not a video", async () => {
+    mockSupabaseClient({ id: "user-1" });
+
+    const { addVideoRecordAction } = await import("./actions");
+    const imageFile = new File(["img"], "photo.jpg", { type: "image/jpeg" });
+    const result = await addVideoRecordAction(
+      "conv-1",
+      undefined,
+      createVideoFormData({ file: imageFile }),
+    );
+
+    expect(result).toEqual({ error: "動画ファイルを選択してください" });
+  });
+
+  it("uploads video with hasAudio true and revalidates on success", async () => {
+    mockSupabaseClient({ id: "user-1" });
+    validateAddMediaRecordInputMock.mockReturnValue(null);
+    addVideoRecordMock.mockResolvedValue({
+      record: { id: "rec-1" },
+      attachment: { id: "att-1" },
+    });
+
+    const { addVideoRecordAction } = await import("./actions");
+    const result = await addVideoRecordAction(
+      "conv-1",
+      undefined,
+      createVideoFormData({ title: "動画タイトル", hasAudio: "true" }),
+    );
+
+    expect(result).toBeUndefined();
+    expect(addVideoRecordMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        userId: "user-1",
+        conversationId: "conv-1",
+        title: "動画タイトル",
+        filename: "clip.mp4",
+        contentType: "video/mp4",
+        hasAudio: true,
+      }),
+    );
+    expect(revalidatePathMock).toHaveBeenCalledWith("/conversations/conv-1");
+  });
+
+  it("sets hasAudio to false when checkbox is unchecked", async () => {
+    mockSupabaseClient({ id: "user-1" });
+    validateAddMediaRecordInputMock.mockReturnValue(null);
+    addVideoRecordMock.mockResolvedValue({
+      record: { id: "rec-1" },
+      attachment: { id: "att-1" },
+    });
+
+    const { addVideoRecordAction } = await import("./actions");
+    await addVideoRecordAction(
+      "conv-1",
+      undefined,
+      createVideoFormData(),
+    );
+
+    expect(addVideoRecordMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ hasAudio: false }),
     );
   });
 });

--- a/src/app/(app)/conversations/[id]/actions.ts
+++ b/src/app/(app)/conversations/[id]/actions.ts
@@ -13,6 +13,7 @@ import {
   addTextRecord,
   validateAddTextRecordInput,
   addImageRecord,
+  addVideoRecord,
   validateAddMediaRecordInput,
   updateExistingRecord,
   validateUpdateRecordInput,
@@ -227,6 +228,66 @@ export async function addImageRecordAction(
   }
 
   await addImageRecord(supabase, input);
+
+  revalidatePath(`/conversations/${conversationId}`);
+
+  return undefined;
+}
+
+const MAX_VIDEO_FILE_SIZE = 50 * 1024 * 1024; // 50MB
+
+export async function addVideoRecordAction(
+  conversationId: string,
+  _prevState: ActionState,
+  formData: FormData,
+): Promise<ActionState> {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const file = formData.get("file");
+  if (!(file instanceof File) || file.size === 0) {
+    return { error: "動画ファイルを選択してください" };
+  }
+
+  if (file.size > MAX_VIDEO_FILE_SIZE) {
+    return { error: "ファイルサイズは50MB以内にしてください" };
+  }
+
+  if (!file.type.startsWith("video/")) {
+    return { error: "動画ファイルを選択してください" };
+  }
+
+  const hasAudioValue = formData.get("hasAudio");
+  const hasAudio = hasAudioValue === "true";
+
+  const titleValue = getOptionalStringField(formData, "title");
+  if (titleValue === null) {
+    return { error: "タイトルのデータが不正です" };
+  }
+
+  const input = {
+    userId: user.id,
+    conversationId,
+    title: titleValue || null,
+    content: null,
+    file,
+    filename: file.name,
+    contentType: file.type,
+    hasAudio,
+  };
+
+  const validationError = validateAddMediaRecordInput(input);
+  if (validationError) {
+    return { error: validationError };
+  }
+
+  await addVideoRecord(supabase, input);
 
   revalidatePath(`/conversations/${conversationId}`);
 

--- a/src/app/(app)/conversations/[id]/page.tsx
+++ b/src/app/(app)/conversations/[id]/page.tsx
@@ -5,6 +5,7 @@ import { ConversationActions } from "@/components/ConversationActions";
 import { RecordTimeline } from "@/components/RecordTimeline";
 import { AddTextRecordForm } from "@/components/AddTextRecordForm";
 import { AddImageRecordForm } from "@/components/AddImageRecordForm";
+import { AddVideoRecordForm } from "@/components/AddVideoRecordForm";
 
 type ConversationDetailPageProps = {
   params: Promise<{ id: string }>;
@@ -46,6 +47,10 @@ export default async function ConversationDetailPage({
       <div className="mt-8 border-t border-gray-200 pt-6">
         <h2 className="mb-3 text-lg font-semibold">画像を追加</h2>
         <AddImageRecordForm conversationId={conversation.id} />
+      </div>
+      <div className="mt-8 border-t border-gray-200 pt-6">
+        <h2 className="mb-3 text-lg font-semibold">動画を追加</h2>
+        <AddVideoRecordForm conversationId={conversation.id} />
       </div>
     </div>
   );

--- a/src/components/AddVideoRecordForm.test.tsx
+++ b/src/components/AddVideoRecordForm.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AddVideoRecordForm } from "./AddVideoRecordForm";
+
+vi.mock("@/app/(app)/conversations/[id]/actions", () => ({
+  addVideoRecordAction: vi.fn(),
+}));
+
+describe("AddVideoRecordForm", () => {
+  it("renders all form fields", () => {
+    render(<AddVideoRecordForm conversationId="conv-1" />);
+
+    expect(screen.getByLabelText("タイトル（任意）")).toBeInTheDocument();
+    expect(screen.getByLabelText("動画ファイル")).toBeInTheDocument();
+    expect(screen.getByLabelText("音声あり")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "動画を追加" }),
+    ).toBeInTheDocument();
+  });
+
+  it("has file input as required with video accept", () => {
+    render(<AddVideoRecordForm conversationId="conv-1" />);
+
+    const fileInput = screen.getByLabelText("動画ファイル");
+    expect(fileInput).toBeRequired();
+    expect(fileInput).toHaveAttribute("accept", "video/*");
+    expect(fileInput).toHaveAttribute("type", "file");
+  });
+
+  it("has hasAudio checkbox checked by default", () => {
+    render(<AddVideoRecordForm conversationId="conv-1" />);
+
+    const checkbox = screen.getByLabelText("音声あり");
+    expect(checkbox).toBeChecked();
+    expect(checkbox).toHaveAttribute("type", "checkbox");
+  });
+
+  it("has title input as optional", () => {
+    render(<AddVideoRecordForm conversationId="conv-1" />);
+
+    expect(screen.getByLabelText("タイトル（任意）")).not.toBeRequired();
+  });
+});

--- a/src/components/AddVideoRecordForm.tsx
+++ b/src/components/AddVideoRecordForm.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useActionState, useRef, useState } from "react";
+import {
+  addVideoRecordAction,
+  type ActionState,
+} from "@/app/(app)/conversations/[id]/actions";
+
+type AddVideoRecordFormProps = {
+  conversationId: string;
+};
+
+const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
+
+export function AddVideoRecordForm({
+  conversationId,
+}: AddVideoRecordFormProps) {
+  const formRef = useRef<HTMLFormElement>(null);
+  const [clientError, setClientError] = useState<string | null>(null);
+
+  const [state, formAction, isPending] = useActionState<
+    ActionState,
+    FormData
+  >(async (_prevState, formData) => {
+    setClientError(null);
+    const result = await addVideoRecordAction(
+      conversationId,
+      _prevState,
+      formData,
+    );
+    if (!result?.error) {
+      formRef.current?.reset();
+    }
+    return result;
+  }, undefined);
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setClientError(null);
+    const file = e.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      setClientError("ファイルサイズは50MB以内にしてください");
+      e.target.value = "";
+      return;
+    }
+
+    if (!file.type.startsWith("video/")) {
+      setClientError("動画ファイルを選択してください");
+      e.target.value = "";
+      return;
+    }
+  }
+
+  const displayError = clientError ?? state?.error;
+
+  return (
+    <form ref={formRef} action={formAction} className="space-y-3">
+      <div>
+        <label
+          htmlFor="video-record-title"
+          className="block text-sm font-medium"
+        >
+          タイトル（任意）
+        </label>
+        <input
+          id="video-record-title"
+          name="title"
+          type="text"
+          maxLength={200}
+          className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="video-record-file"
+          className="block text-sm font-medium"
+        >
+          動画ファイル
+        </label>
+        <input
+          id="video-record-file"
+          name="file"
+          type="file"
+          accept="video/*"
+          required
+          onChange={handleFileChange}
+          className="mt-1 block w-full text-sm"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <input
+          id="video-record-has-audio"
+          name="hasAudio"
+          type="checkbox"
+          value="true"
+          defaultChecked
+          className="h-4 w-4 rounded border-gray-300"
+        />
+        <label
+          htmlFor="video-record-has-audio"
+          className="text-sm font-medium"
+        >
+          音声あり
+        </label>
+      </div>
+
+      {displayError && (
+        <p className="text-sm text-red-600">{displayError}</p>
+      )}
+
+      <button
+        type="submit"
+        disabled={isPending}
+        className="rounded bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50"
+      >
+        {isPending ? "アップロード中..." : "動画を追加"}
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- `AddVideoRecordForm` コンポーネント作成（動画ファイル選択、音声ありトグル、クライアントバリデーション）
- `addVideoRecordAction` Server Action 追加（認証、50MBサイズ制限、video/* タイプチェック）
- 会話詳細ページに動画アップロードフォームセクションを追加

## Detail
- 動画ファイル（必須）、タイトル（任意）、音声ありチェックボックス（デフォルトON）
- `accept="video/*"` でファイル種別制限
- クライアント側・サーバー側で50MBサイズ制限
- checkbox の `value="true"` と `defaultChecked` で、チェック時に `hasAudio=true` を送信、未チェック時はフィールド自体が送信されないため `false` となる

## Test plan
- [x] コンポーネントテスト4件（フィールド表示、file required/accept、checkbox デフォルトチェック、title optional）
- [x] Server Action テスト6件（認証、ファイル欠損/サイズ超過/非動画、成功+hasAudio true、hasAudio false）
- [x] 既存テスト全280件通過
- [x] TypeScript 型チェック通過

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)