### PR TITLE
feat: add audio record upload form

### DIFF
--- a/src/app/(app)/conversations/[id]/actions.test.ts
+++ b/src/app/(app)/conversations/[id]/actions.test.ts
@@ -17,6 +17,7 @@ const validateAddTextRecordInputMock = vi.fn();
 const addTextRecordMock = vi.fn();
 const addImageRecordMock = vi.fn();
 const addVideoRecordMock = vi.fn();
+const addAudioRecordMock = vi.fn();
 const validateAddMediaRecordInputMock = vi.fn();
 const validateUpdateConversationInputMock = vi.fn();
 const updateExistingConversationMock = vi.fn();
@@ -48,6 +49,7 @@ vi.mock("@/usecases/recordUseCases", () => ({
   addTextRecord: addTextRecordMock,
   addImageRecord: addImageRecordMock,
   addVideoRecord: addVideoRecordMock,
+  addAudioRecord: addAudioRecordMock,
   validateAddMediaRecordInput: validateAddMediaRecordInputMock,
   validateUpdateRecordInput: validateUpdateRecordInputMock,
   updateExistingRecord: updateExistingRecordMock,
@@ -727,5 +729,113 @@ describe("addVideoRecordAction", () => {
       expect.anything(),
       expect.objectContaining({ hasAudio: false }),
     );
+  });
+});
+
+function createAudioFormData(overrides?: {
+  file?: File;
+  title?: string;
+}): FormData {
+  const formData = new FormData();
+  const file =
+    overrides?.file ??
+    new File(["audio-data"], "voice.mp3", { type: "audio/mpeg" });
+  formData.set("file", file);
+  if (overrides?.title !== undefined) {
+    formData.set("title", overrides.title);
+  }
+  return formData;
+}
+
+describe("addAudioRecordAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("redirects to login when not authenticated", async () => {
+    mockSupabaseClient(null);
+
+    const { addAudioRecordAction } = await import("./actions");
+    await expect(
+      addAudioRecordAction("conv-1", undefined, createAudioFormData()),
+    ).rejects.toThrow("NEXT_REDIRECT: /login");
+  });
+
+  it("returns error when file is missing", async () => {
+    mockSupabaseClient({ id: "user-1" });
+
+    const { addAudioRecordAction } = await import("./actions");
+    const result = await addAudioRecordAction(
+      "conv-1",
+      undefined,
+      new FormData(),
+    );
+
+    expect(result).toEqual({ error: "音声ファイルを選択してください" });
+    expect(addAudioRecordMock).not.toHaveBeenCalled();
+  });
+
+  it("returns error when file exceeds 50MB", async () => {
+    mockSupabaseClient({ id: "user-1" });
+
+    const { addAudioRecordAction } = await import("./actions");
+    const largeFile = new File(
+      [new ArrayBuffer(50 * 1024 * 1024 + 1)],
+      "large.mp3",
+      { type: "audio/mpeg" },
+    );
+    const result = await addAudioRecordAction(
+      "conv-1",
+      undefined,
+      createAudioFormData({ file: largeFile }),
+    );
+
+    expect(result).toEqual({
+      error: "ファイルサイズは50MB以内にしてください",
+    });
+  });
+
+  it("returns error when file is not audio", async () => {
+    mockSupabaseClient({ id: "user-1" });
+
+    const { addAudioRecordAction } = await import("./actions");
+    const imageFile = new File(["img"], "photo.jpg", { type: "image/jpeg" });
+    const result = await addAudioRecordAction(
+      "conv-1",
+      undefined,
+      createAudioFormData({ file: imageFile }),
+    );
+
+    expect(result).toEqual({ error: "音声ファイルを選択してください" });
+  });
+
+  it("uploads audio and revalidates on success", async () => {
+    mockSupabaseClient({ id: "user-1" });
+    validateAddMediaRecordInputMock.mockReturnValue(null);
+    addAudioRecordMock.mockResolvedValue({
+      record: { id: "rec-1" },
+      attachment: { id: "att-1" },
+    });
+
+    const { addAudioRecordAction } = await import("./actions");
+    const result = await addAudioRecordAction(
+      "conv-1",
+      undefined,
+      createAudioFormData({ title: "音声タイトル" }),
+    );
+
+    expect(result).toBeUndefined();
+    expect(addAudioRecordMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        userId: "user-1",
+        conversationId: "conv-1",
+        title: "音声タイトル",
+        content: null,
+        filename: "voice.mp3",
+        contentType: "audio/mpeg",
+      }),
+    );
+    expect(revalidatePathMock).toHaveBeenCalledWith("/conversations/conv-1");
   });
 });

--- a/src/app/(app)/conversations/[id]/actions.ts
+++ b/src/app/(app)/conversations/[id]/actions.ts
@@ -14,6 +14,7 @@ import {
   validateAddTextRecordInput,
   addImageRecord,
   addVideoRecord,
+  addAudioRecord,
   validateAddMediaRecordInput,
   updateExistingRecord,
   validateUpdateRecordInput,
@@ -288,6 +289,62 @@ export async function addVideoRecordAction(
   }
 
   await addVideoRecord(supabase, input);
+
+  revalidatePath(`/conversations/${conversationId}`);
+
+  return undefined;
+}
+
+const MAX_AUDIO_FILE_SIZE = 50 * 1024 * 1024; // 50MB
+
+export async function addAudioRecordAction(
+  conversationId: string,
+  _prevState: ActionState,
+  formData: FormData,
+): Promise<ActionState> {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const file = formData.get("file");
+  if (!(file instanceof File) || file.size === 0) {
+    return { error: "音声ファイルを選択してください" };
+  }
+
+  if (file.size > MAX_AUDIO_FILE_SIZE) {
+    return { error: "ファイルサイズは50MB以内にしてください" };
+  }
+
+  if (!file.type.startsWith("audio/")) {
+    return { error: "音声ファイルを選択してください" };
+  }
+
+  const titleValue = getOptionalStringField(formData, "title");
+  if (titleValue === null) {
+    return { error: "タイトルのデータが不正です" };
+  }
+
+  const input = {
+    userId: user.id,
+    conversationId,
+    title: titleValue || null,
+    content: null,
+    file,
+    filename: file.name,
+    contentType: file.type,
+  };
+
+  const validationError = validateAddMediaRecordInput(input);
+  if (validationError) {
+    return { error: validationError };
+  }
+
+  await addAudioRecord(supabase, input);
 
   revalidatePath(`/conversations/${conversationId}`);
 

--- a/src/app/(app)/conversations/[id]/page.tsx
+++ b/src/app/(app)/conversations/[id]/page.tsx
@@ -6,6 +6,7 @@ import { RecordTimeline } from "@/components/RecordTimeline";
 import { AddTextRecordForm } from "@/components/AddTextRecordForm";
 import { AddImageRecordForm } from "@/components/AddImageRecordForm";
 import { AddVideoRecordForm } from "@/components/AddVideoRecordForm";
+import { AddAudioRecordForm } from "@/components/AddAudioRecordForm";
 
 type ConversationDetailPageProps = {
   params: Promise<{ id: string }>;
@@ -51,6 +52,10 @@ export default async function ConversationDetailPage({
       <div className="mt-8 border-t border-gray-200 pt-6">
         <h2 className="mb-3 text-lg font-semibold">動画を追加</h2>
         <AddVideoRecordForm conversationId={conversation.id} />
+      </div>
+      <div className="mt-8 border-t border-gray-200 pt-6">
+        <h2 className="mb-3 text-lg font-semibold">音声を追加</h2>
+        <AddAudioRecordForm conversationId={conversation.id} />
       </div>
     </div>
   );

--- a/src/components/AddAudioRecordForm.test.tsx
+++ b/src/components/AddAudioRecordForm.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AddAudioRecordForm } from "./AddAudioRecordForm";
+
+vi.mock("@/app/(app)/conversations/[id]/actions", () => ({
+  addAudioRecordAction: vi.fn(),
+}));
+
+describe("AddAudioRecordForm", () => {
+  it("renders all form fields", () => {
+    render(<AddAudioRecordForm conversationId="conv-1" />);
+
+    expect(screen.getByLabelText("タイトル（任意）")).toBeInTheDocument();
+    expect(screen.getByLabelText("音声ファイル")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "音声を追加" }),
+    ).toBeInTheDocument();
+  });
+
+  it("has file input as required with audio accept", () => {
+    render(<AddAudioRecordForm conversationId="conv-1" />);
+
+    const fileInput = screen.getByLabelText("音声ファイル");
+    expect(fileInput).toBeRequired();
+    expect(fileInput).toHaveAttribute("accept", "audio/*");
+    expect(fileInput).toHaveAttribute("type", "file");
+  });
+
+  it("has title input as optional", () => {
+    render(<AddAudioRecordForm conversationId="conv-1" />);
+
+    expect(screen.getByLabelText("タイトル（任意）")).not.toBeRequired();
+  });
+});

--- a/src/components/AddAudioRecordForm.tsx
+++ b/src/components/AddAudioRecordForm.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useActionState, useRef, useState } from "react";
+import {
+  addAudioRecordAction,
+  type ActionState,
+} from "@/app/(app)/conversations/[id]/actions";
+
+type AddAudioRecordFormProps = {
+  conversationId: string;
+};
+
+const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
+
+export function AddAudioRecordForm({
+  conversationId,
+}: AddAudioRecordFormProps) {
+  const formRef = useRef<HTMLFormElement>(null);
+  const [clientError, setClientError] = useState<string | null>(null);
+
+  const [state, formAction, isPending] = useActionState<
+    ActionState,
+    FormData
+  >(async (_prevState, formData) => {
+    setClientError(null);
+    const result = await addAudioRecordAction(
+      conversationId,
+      _prevState,
+      formData,
+    );
+    if (!result?.error) {
+      formRef.current?.reset();
+    }
+    return result;
+  }, undefined);
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setClientError(null);
+    const file = e.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      setClientError("ファイルサイズは50MB以内にしてください");
+      e.target.value = "";
+      return;
+    }
+
+    if (!file.type.startsWith("audio/")) {
+      setClientError("音声ファイルを選択してください");
+      e.target.value = "";
+      return;
+    }
+  }
+
+  const displayError = clientError ?? state?.error;
+
+  return (
+    <form ref={formRef} action={formAction} className="space-y-3">
+      <div>
+        <label
+          htmlFor="audio-record-title"
+          className="block text-sm font-medium"
+        >
+          タイトル（任意）
+        </label>
+        <input
+          id="audio-record-title"
+          name="title"
+          type="text"
+          maxLength={200}
+          className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="audio-record-file"
+          className="block text-sm font-medium"
+        >
+          音声ファイル
+        </label>
+        <input
+          id="audio-record-file"
+          name="file"
+          type="file"
+          accept="audio/*"
+          required
+          onChange={handleFileChange}
+          className="mt-1 block w-full text-sm"
+        />
+      </div>
+
+      {displayError && (
+        <p className="text-sm text-red-600">{displayError}</p>
+      )}
+
+      <button
+        type="submit"
+        disabled={isPending}
+        className="rounded bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50"
+      >
+        {isPending ? "アップロード中..." : "音声を追加"}
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- `AddAudioRecordForm` コンポーネント作成（音声ファイル選択、クライアントバリデーション）
- `addAudioRecordAction` Server Action 追加（認証、50MBサイズ制限、audio/* タイプチェック）
- 会話詳細ページに音声アップロードフォームセクションを追加

## Detail
- 音声ファイル（必須）、タイトル（任意）の2フィールド
- `accept="audio/*"` でファイル種別制限
- クライアント側・サーバー側で50MBサイズ制限
- 画像・動画フォームと同じパターンで統一的に実装

## Test plan
- [x] コンポーネントテスト3件（フィールド表示、file required/accept、title optional）
- [x] Server Action テスト5件（認証、ファイル欠損/サイズ超過/非音声、成功）
- [x] 既存テスト全288件通過
- [x] TypeScript 型チェック通過

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)