### PR TITLE
feat: グローバル検索UIの実装 (#29)

### DIFF
--- a/src/app/(app)/search/page.tsx
+++ b/src/app/(app)/search/page.tsx
@@ -1,0 +1,53 @@
+import { redirect } from "next/navigation";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { searchRecords } from "@/usecases/searchUseCases";
+import { SearchResults } from "@/components/SearchResults";
+
+type SearchPageProps = {
+  searchParams: Promise<{ q?: string }>;
+};
+
+export default async function SearchPage({ searchParams }: SearchPageProps) {
+  const { q } = await searchParams;
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const query = q?.trim() ?? "";
+  const results =
+    query.length > 0
+      ? await searchRecords(supabase, { userId: user.id, query })
+      : null;
+
+  return (
+    <div>
+      <h1 className="text-lg font-bold">検索</h1>
+
+      <form className="mt-4 flex items-center gap-3">
+        <input
+          name="q"
+          type="text"
+          defaultValue={query}
+          placeholder="レコードを検索..."
+          className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm"
+        />
+        <button
+          type="submit"
+          className="rounded bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+        >
+          検索
+        </button>
+      </form>
+
+      {query.length > 0 && results && (
+        <SearchResults results={results} query={query} />
+      )}
+    </div>
+  );
+}

--- a/src/components/SearchResults.test.tsx
+++ b/src/components/SearchResults.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SearchResults } from "./SearchResults";
+import type { SearchRecordResult } from "@/types/domain";
+
+const baseResult: SearchRecordResult = {
+  id: "rec-1",
+  conversationId: "conv-1",
+  recordType: "text",
+  title: null,
+  content: "テストメッセージ内容",
+  hasAudio: false,
+  speakerParticipantId: "part-1",
+  postedAt: "2026-01-01T10:00:00+09:00",
+  position: 0,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+  conversationTitle: "テスト会話",
+};
+
+describe("SearchResults", () => {
+  it("shows empty message when no results", () => {
+    render(<SearchResults results={[]} query="テスト" />);
+
+    expect(
+      screen.getByText("「テスト」に一致する結果はありません。"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows result count", () => {
+    render(<SearchResults results={[baseResult]} query="テスト" />);
+
+    expect(screen.getByText("1件の結果")).toBeInTheDocument();
+  });
+
+  it("renders result content", () => {
+    render(<SearchResults results={[baseResult]} query="テスト" />);
+
+    expect(screen.getByText("テストメッセージ内容")).toBeInTheDocument();
+  });
+
+  it("renders conversation title", () => {
+    render(<SearchResults results={[baseResult]} query="テスト" />);
+
+    expect(screen.getByText("テスト会話")).toBeInTheDocument();
+  });
+
+  it("renders record type badge", () => {
+    render(<SearchResults results={[baseResult]} query="テスト" />);
+
+    expect(screen.getByText("テキスト")).toBeInTheDocument();
+  });
+
+  it("links to conversation with recordId", () => {
+    render(<SearchResults results={[baseResult]} query="テスト" />);
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute(
+      "href",
+      "/conversations/conv-1?recordId=rec-1",
+    );
+  });
+
+  it("shows title when content is absent", () => {
+    const result = {
+      ...baseResult,
+      content: null,
+      title: "レコードタイトル",
+    };
+    render(<SearchResults results={[result]} query="テスト" />);
+
+    expect(screen.getByText("レコードタイトル")).toBeInTheDocument();
+  });
+
+  it("shows file type placeholder when no content or title", () => {
+    const result = {
+      ...baseResult,
+      content: null,
+      title: null,
+      recordType: "image" as const,
+    };
+    render(<SearchResults results={[result]} query="テスト" />);
+
+    expect(screen.getByText("(画像ファイル)")).toBeInTheDocument();
+  });
+
+  it("truncates long content", () => {
+    const longContent = "あ".repeat(200);
+    const result = { ...baseResult, content: longContent };
+    render(<SearchResults results={[result]} query="テスト" />);
+
+    const truncated = "あ".repeat(150) + "…";
+    expect(screen.getByText(truncated)).toBeInTheDocument();
+  });
+
+  it("renders multiple results", () => {
+    const results = [
+      baseResult,
+      {
+        ...baseResult,
+        id: "rec-2",
+        content: "二つ目の結果",
+        conversationTitle: "別の会話",
+      },
+    ];
+    render(<SearchResults results={results} query="テスト" />);
+
+    expect(screen.getByText("2件の結果")).toBeInTheDocument();
+    expect(screen.getAllByRole("link")).toHaveLength(2);
+  });
+});

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import Link from "next/link";
+import { formatDateTimeJst } from "@/lib/dateTime";
+import type { RecordType, SearchRecordResult } from "@/types/domain";
+
+type SearchResultsProps = {
+  results: SearchRecordResult[];
+  query: string;
+};
+
+const recordTypeLabels: { [K in RecordType]: string } = {
+  text: "テキスト",
+  image: "画像",
+  video: "動画",
+  audio: "音声",
+};
+
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength) + "…";
+}
+
+export function SearchResults({ results, query }: SearchResultsProps) {
+  if (results.length === 0) {
+    return (
+      <p className="mt-6 text-sm text-gray-500">
+        「{query}」に一致する結果はありません。
+      </p>
+    );
+  }
+
+  return (
+    <div className="mt-4">
+      <p className="mb-3 text-sm text-gray-600">
+        {results.length}件の結果
+      </p>
+      <ul className="space-y-2">
+        {results.map((result) => (
+          <li key={result.id}>
+            <Link
+              href={`/conversations/${result.conversationId}?recordId=${result.id}`}
+              className="block rounded-lg border border-gray-200 px-4 py-3 transition-colors hover:bg-gray-50"
+            >
+              <div className="flex items-center gap-2">
+                <span className="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-600">
+                  {recordTypeLabels[result.recordType]}
+                </span>
+                <span className="text-xs text-gray-500">
+                  {formatDateTimeJst(result.postedAt)}
+                </span>
+              </div>
+              <p className="mt-1 text-xs font-medium text-gray-500">
+                {result.conversationTitle}
+              </p>
+              {result.content && (
+                <p className="mt-1 text-sm text-gray-700">
+                  {truncate(result.content, 150)}
+                </p>
+              )}
+              {result.title && !result.content && (
+                <p className="mt-1 text-sm font-medium text-gray-700">
+                  {truncate(result.title, 150)}
+                </p>
+              )}
+              {!result.content && !result.title && (
+                <p className="mt-1 text-sm text-gray-400">
+                  ({recordTypeLabels[result.recordType]}ファイル)
+                </p>
+              )}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -21,6 +21,13 @@ describe("Sidebar", () => {
     expect(navLink).toHaveAttribute("href", "/");
   });
 
+  it("renders navigation link for search", () => {
+    render(<Sidebar userEmail="test@example.com" />);
+
+    const navLink = screen.getByRole("link", { name: "検索" });
+    expect(navLink).toHaveAttribute("href", "/search");
+  });
+
   it("displays user email", () => {
     render(<Sidebar userEmail="test@example.com" />);
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -24,6 +24,14 @@ export function Sidebar({ userEmail }: SidebarProps) {
               会話一覧
             </Link>
           </li>
+          <li>
+            <Link
+              href="/search"
+              className="block rounded px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200"
+            >
+              検索
+            </Link>
+          </li>
         </ul>
       </nav>
 


### PR DESCRIPTION
## Summary
- **検索ページ** (`/search?q=...`): GETフォームで検索クエリを送信し、サーバーサイドで `searchRecords` ユースケース経由で検索実行
- **SearchResults コンポーネント**: 検索結果をカード形式で表示（レコードタイプバッジ、日時、会話タイトル、コンテンツスニペット）。空結果時は「一致する結果はありません」メッセージ
- **Sidebar**: 「検索」ナビゲーションリンクを追加（どのページからでもアクセス可能）
- 結果クリックで `?recordId=` 付きで該当会話ページへ遷移し、該当レコード位置へスクロール

## Test plan
- [x] `SearchResults` コンポーネントテスト（空結果、件数表示、リンク先、コンテンツ切り詰め、複数結果）
- [x] `Sidebar` テスト更新（検索リンク追加確認）
- [x] 全414テスト通過、型チェック・lint通過

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)