### PR TITLE
feat: エラーハンドリングとローディング状態の実装 (#32)

### DIFF
--- a/src/app/(app)/conversations/[id]/actions.ts
+++ b/src/app/(app)/conversations/[id]/actions.ts
@@ -243,7 +243,12 @@ export async function addTextRecordAction(
     return { error: validationError };
   }
 
-  await addTextRecord(supabase, input);
+  try {
+    await addTextRecord(supabase, input);
+  } catch (error) {
+    console.error("Failed to add text record:", error);
+    return { error: "テキストレコードの追加に失敗しました。時間をおいて再度お試しください。" };
+  }
 
   revalidatePath(`/conversations/${conversationId}`);
 
@@ -323,7 +328,12 @@ export async function addImageRecordAction(
     return { error: validationError };
   }
 
-  await addImageRecord(supabase, input);
+  try {
+    await addImageRecord(supabase, input);
+  } catch (error) {
+    console.error("Failed to add image record:", error);
+    return { error: "画像レコードの追加に失敗しました。時間をおいて再度お試しください。" };
+  }
 
   revalidatePath(`/conversations/${conversationId}`);
 
@@ -402,7 +412,12 @@ export async function addVideoRecordAction(
     return { error: validationError };
   }
 
-  await addVideoRecord(supabase, input);
+  try {
+    await addVideoRecord(supabase, input);
+  } catch (error) {
+    console.error("Failed to add video record:", error);
+    return { error: "動画レコードの追加に失敗しました。時間をおいて再度お試しください。" };
+  }
 
   revalidatePath(`/conversations/${conversationId}`);
 
@@ -477,7 +492,12 @@ export async function addAudioRecordAction(
     return { error: validationError };
   }
 
-  await addAudioRecord(supabase, input);
+  try {
+    await addAudioRecord(supabase, input);
+  } catch (error) {
+    console.error("Failed to add audio record:", error);
+    return { error: "音声レコードの追加に失敗しました。時間をおいて再度お試しください。" };
+  }
 
   revalidatePath(`/conversations/${conversationId}`);
 
@@ -540,7 +560,12 @@ export async function updateConversationAction(
     return { error: validationError };
   }
 
-  await updateExistingConversation(supabase, conversationId, input);
+  try {
+    await updateExistingConversation(supabase, conversationId, input);
+  } catch (error) {
+    console.error("Failed to update conversation:", error);
+    return { error: "会話の更新に失敗しました。時間をおいて再度お試しください。" };
+  }
 
   revalidatePath(`/conversations/${conversationId}`);
 
@@ -549,7 +574,7 @@ export async function updateConversationAction(
 
 export async function deleteConversationAction(
   conversationId: string,
-): Promise<void> {
+): Promise<{ error: string } | void> {
   const supabase = await createSupabaseServerClient();
   const {
     data: { user },
@@ -559,7 +584,12 @@ export async function deleteConversationAction(
     redirect("/login");
   }
 
-  await deleteExistingConversation(supabase, conversationId);
+  try {
+    await deleteExistingConversation(supabase, conversationId);
+  } catch (error) {
+    console.error("Failed to delete conversation:", error);
+    return { error: "会話の削除に失敗しました。時間をおいて再度お試しください。" };
+  }
 
   redirect("/");
 }
@@ -599,7 +629,12 @@ export async function updateRecordAction(
     return { error: validationError };
   }
 
-  await updateExistingRecord(supabase, recordId, input);
+  try {
+    await updateExistingRecord(supabase, recordId, input);
+  } catch (error) {
+    console.error("Failed to update record:", error);
+    return { error: "レコードの更新に失敗しました。時間をおいて再度お試しください。" };
+  }
 
   revalidatePath(`/conversations/${conversationId}`);
 
@@ -609,7 +644,7 @@ export async function updateRecordAction(
 export async function deleteRecordAction(
   conversationId: string,
   recordId: string,
-): Promise<void> {
+): Promise<{ error: string } | void> {
   const supabase = await createSupabaseServerClient();
   const {
     data: { user },
@@ -619,7 +654,12 @@ export async function deleteRecordAction(
     redirect("/login");
   }
 
-  await deleteExistingRecord(supabase, recordId);
+  try {
+    await deleteExistingRecord(supabase, recordId);
+  } catch (error) {
+    console.error("Failed to delete record:", error);
+    return { error: "レコードの削除に失敗しました。時間をおいて再度お試しください。" };
+  }
 
   revalidatePath(`/conversations/${conversationId}`);
 }

--- a/src/app/(app)/conversations/[id]/loading.tsx
+++ b/src/app/(app)/conversations/[id]/loading.tsx
@@ -1,0 +1,76 @@
+import { Skeleton } from "@/components/Skeleton";
+
+export default function ConversationLoading() {
+  return (
+    <div className="-m-6 flex h-[100vh] flex-col bg-gray-100">
+      {/* Header */}
+      <div className="flex items-center gap-2 border-b border-gray-300 bg-white px-4 py-3">
+        <Skeleton className="h-5 w-5" />
+        <Skeleton className="h-5 flex-1" />
+        <Skeleton className="h-5 w-5" />
+        <Skeleton className="h-5 w-5" />
+      </div>
+
+      {/* Timeline */}
+      <div className="flex-1 space-y-4 overflow-hidden px-4 py-4">
+        {/* Date header */}
+        <div className="flex justify-center">
+          <Skeleton className="h-5 w-24 rounded-full" />
+        </div>
+
+        {/* Messages - alternating left/right */}
+        <div className="flex items-start gap-2">
+          <Skeleton className="h-8 w-8 rounded-full" />
+          <div className="space-y-1">
+            <Skeleton className="h-3 w-16" />
+            <Skeleton className="h-12 w-48 rounded-lg" />
+          </div>
+        </div>
+
+        <div className="flex items-start gap-2">
+          <Skeleton className="h-8 w-8 rounded-full" />
+          <div className="space-y-1">
+            <Skeleton className="h-3 w-20" />
+            <Skeleton className="h-20 w-56 rounded-lg" />
+          </div>
+        </div>
+
+        <div className="flex items-start gap-2">
+          <Skeleton className="h-8 w-8 rounded-full" />
+          <div className="space-y-1">
+            <Skeleton className="h-3 w-14" />
+            <Skeleton className="h-10 w-40 rounded-lg" />
+          </div>
+        </div>
+
+        <div className="flex justify-center">
+          <Skeleton className="h-5 w-24 rounded-full" />
+        </div>
+
+        <div className="flex items-start gap-2">
+          <Skeleton className="h-8 w-8 rounded-full" />
+          <div className="space-y-1">
+            <Skeleton className="h-3 w-18" />
+            <Skeleton className="h-14 w-52 rounded-lg" />
+          </div>
+        </div>
+
+        <div className="flex items-start gap-2">
+          <Skeleton className="h-8 w-8 rounded-full" />
+          <div className="space-y-1">
+            <Skeleton className="h-3 w-16" />
+            <Skeleton className="h-10 w-36 rounded-lg" />
+          </div>
+        </div>
+      </div>
+
+      {/* Composer */}
+      <div className="border-t border-gray-300 bg-white px-4 py-3">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-10 flex-1 rounded" />
+          <Skeleton className="h-10 w-16 rounded" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/conversations/new/actions.ts
+++ b/src/app/(app)/conversations/new/actions.ts
@@ -126,7 +126,13 @@ export async function createConversationAction(
     return { error: validationError };
   }
 
-  const conversation = await createNewConversation(supabase, input);
+  let conversation;
+  try {
+    conversation = await createNewConversation(supabase, input);
+  } catch (error) {
+    console.error("Failed to create conversation:", error);
+    return { error: "会話の作成に失敗しました。時間をおいて再度お試しください。" };
+  }
 
   redirect(`/conversations/${conversation.id}`);
 }

--- a/src/app/(app)/error.tsx
+++ b/src/app/(app)/error.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+
+type ErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function AppError({ error, reset }: ErrorPageProps) {
+  useEffect(() => {
+    console.error("Unhandled error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center py-20">
+      <h1 className="text-2xl font-bold">エラーが発生しました</h1>
+      <p className="mt-2 text-sm text-gray-500">
+        予期せぬエラーが発生しました。時間をおいて再度お試しください。
+      </p>
+      <div className="mt-6 flex gap-3">
+        <button
+          type="button"
+          onClick={reset}
+          className="rounded bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+        >
+          再試行
+        </button>
+        <Link
+          href="/"
+          className="rounded border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+        >
+          会話一覧に戻る
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/loading.tsx
+++ b/src/app/(app)/loading.tsx
@@ -1,0 +1,33 @@
+import { Skeleton } from "@/components/Skeleton";
+
+export default function HomeLoading() {
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-8 w-32" />
+        <Skeleton className="h-10 w-24 rounded" />
+      </div>
+
+      {/* Tab bar */}
+      <div className="mt-4 flex gap-2 border-b border-gray-200 pb-2">
+        <Skeleton className="h-8 w-20 rounded-full" />
+        <Skeleton className="h-8 w-20 rounded-full" />
+        <Skeleton className="h-8 w-20 rounded-full" />
+        <Skeleton className="h-8 w-20 rounded-full" />
+      </div>
+
+      {/* Card grid */}
+      <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="overflow-hidden rounded-lg border border-gray-200">
+            <Skeleton className="h-40 w-full rounded-none" />
+            <div className="space-y-2 p-3">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-3 w-1/2" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/search/loading.tsx
+++ b/src/app/(app)/search/loading.tsx
@@ -1,0 +1,14 @@
+import { Skeleton } from "@/components/Skeleton";
+
+export default function SearchLoading() {
+  return (
+    <div>
+      <Skeleton className="h-7 w-16" />
+
+      <div className="mt-4 flex items-center gap-3">
+        <Skeleton className="h-10 flex-1 rounded" />
+        <Skeleton className="h-10 w-16 rounded" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+
+type ErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function RootError({ error, reset }: ErrorPageProps) {
+  useEffect(() => {
+    console.error("Unhandled error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center px-4">
+      <h1 className="text-2xl font-bold">エラーが発生しました</h1>
+      <p className="mt-2 text-sm text-gray-500">
+        予期せぬエラーが発生しました。時間をおいて再度お試しください。
+      </p>
+      <div className="mt-6 flex gap-3">
+        <button
+          type="button"
+          onClick={reset}
+          className="rounded bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+        >
+          再試行
+        </button>
+        <Link
+          href="/"
+          className="rounded border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+        >
+          ホームに戻る
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { ToastProvider } from "@/components/ToastProvider";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -27,7 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <ToastProvider>{children}</ToastProvider>
       </body>
     </html>
   );

--- a/src/app/login/actions.test.ts
+++ b/src/app/login/actions.test.ts
@@ -94,7 +94,7 @@ describe("logout", () => {
   });
 
   it("signs out, revalidates and redirects to login", async () => {
-    signOutMock.mockResolvedValue({});
+    signOutMock.mockResolvedValue({ error: null });
 
     const { logout } = await import("./actions");
     await logout();
@@ -102,5 +102,24 @@ describe("logout", () => {
     expect(signOutMock).toHaveBeenCalled();
     expect(revalidatePathMock).toHaveBeenCalledWith("/", "layout");
     expect(redirectMock).toHaveBeenCalledWith("/login");
+  });
+
+  it("returns error and does not redirect when signOut returns error", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    signOutMock.mockResolvedValue({
+      error: new Error("network failure"),
+    });
+
+    const { logout } = await import("./actions");
+    const result = await logout();
+
+    expect(result).toEqual({
+      error: "ログアウトに失敗しました。時間をおいて再度お試しください。",
+    });
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(revalidatePathMock).not.toHaveBeenCalled();
+    expect(redirectMock).not.toHaveBeenCalled();
   });
 });

--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -29,11 +29,22 @@ export async function login(formData: FormData) {
 
 export async function logout() {
   const supabase = await createSupabaseServerClient();
+
   try {
-    await supabase.auth.signOut();
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      console.error("Failed to sign out:", error);
+      return {
+        error: "ログアウトに失敗しました。時間をおいて再度お試しください。",
+      };
+    }
   } catch (error) {
     console.error("Failed to sign out:", error);
+    return {
+      error: "ログアウトに失敗しました。時間をおいて再度お試しください。",
+    };
   }
+
   revalidatePath("/", "layout");
   redirect("/login");
 }

--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -29,7 +29,11 @@ export async function login(formData: FormData) {
 
 export async function logout() {
   const supabase = await createSupabaseServerClient();
-  await supabase.auth.signOut();
+  try {
+    await supabase.auth.signOut();
+  } catch (error) {
+    console.error("Failed to sign out:", error);
+  }
   revalidatePath("/", "layout");
   redirect("/login");
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useActionState } from "react";
+import { FormError } from "@/components/FormError";
 import { login } from "./actions";
 
 type LoginState = { error: string } | undefined;
@@ -52,9 +53,7 @@ export default function LoginPage() {
               className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm"
             />
           </div>
-          {state?.error && (
-            <p className="text-sm text-red-600">{state.error}</p>
-          )}
+          <FormError message={state?.error} />
           <button
             type="submit"
             disabled={isPending}

--- a/src/components/AddImageRecordForm.tsx
+++ b/src/components/AddImageRecordForm.tsx
@@ -6,6 +6,7 @@ import {
   addImageRecordAction,
   type ActionState,
 } from "@/app/(app)/conversations/[id]/actions";
+import { FormError } from "@/components/FormError";
 
 type AddImageRecordFormProps = {
   conversationId: string;
@@ -137,9 +138,7 @@ export function AddImageRecordForm({
         </div>
       )}
 
-      {displayError && (
-        <p className="text-sm text-red-600">{displayError}</p>
-      )}
+      <FormError message={displayError} />
 
       <button
         type="submit"

--- a/src/components/AddTextRecordForm.tsx
+++ b/src/components/AddTextRecordForm.tsx
@@ -5,6 +5,7 @@ import {
   addTextRecordAction,
   type AddTextRecordState,
 } from "@/app/(app)/conversations/[id]/actions";
+import { FormError } from "@/components/FormError";
 
 type AddTextRecordFormProps = {
   conversationId: string;
@@ -58,9 +59,7 @@ export function AddTextRecordForm({
         />
       </div>
 
-      {state?.error && (
-        <p className="text-sm text-red-600">{state.error}</p>
-      )}
+      <FormError message={state?.error} />
 
       <button
         type="submit"

--- a/src/components/ChatComposer.tsx
+++ b/src/components/ChatComposer.tsx
@@ -9,6 +9,7 @@ import {
   addAudioRecordAction,
   type ActionState,
 } from "@/app/(app)/conversations/[id]/actions";
+import { FormError } from "@/components/FormError";
 import type { ConversationParticipant, RecordType } from "@/types/domain";
 
 type ChatComposerProps = {
@@ -263,9 +264,7 @@ export function ChatComposer({
           />
         )}
 
-        {displayError && (
-          <p className="text-xs text-red-600">{displayError}</p>
-        )}
+        <FormError message={displayError} />
 
         <button
           type="submit"

--- a/src/components/ChatMessage.test.tsx
+++ b/src/components/ChatMessage.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ChatMessage } from "./ChatMessage";
+import { ToastProvider } from "./ToastProvider";
 import type { Record } from "@/types/domain";
 
 vi.mock("@/app/(app)/conversations/[id]/actions", () => ({
@@ -31,11 +32,11 @@ const imageRecord: Record = {
 describe("ChatMessage", () => {
   it("renders participant name and initial", () => {
     render(
-      <ChatMessage
+      <ToastProvider><ChatMessage
         record={textRecord}
         participantName="メンバーA"
         conversationId="conv-1"
-      />,
+      /></ToastProvider>,
     );
 
     expect(screen.getByText("メンバーA")).toBeInTheDocument();
@@ -44,11 +45,11 @@ describe("ChatMessage", () => {
 
   it("renders record title and content", () => {
     render(
-      <ChatMessage
+      <ToastProvider><ChatMessage
         record={textRecord}
         participantName="メンバーA"
         conversationId="conv-1"
-      />,
+      /></ToastProvider>,
     );
 
     expect(screen.getByText("テストタイトル")).toBeInTheDocument();
@@ -57,11 +58,11 @@ describe("ChatMessage", () => {
 
   it("renders posted time", () => {
     render(
-      <ChatMessage
+      <ToastProvider><ChatMessage
         record={textRecord}
         participantName="メンバーA"
         conversationId="conv-1"
-      />,
+      /></ToastProvider>,
     );
 
     expect(screen.getByText("19:30")).toBeInTheDocument();
@@ -69,11 +70,11 @@ describe("ChatMessage", () => {
 
   it("switches to edit form when edit button is clicked", () => {
     render(
-      <ChatMessage
+      <ToastProvider><ChatMessage
         record={textRecord}
         participantName="メンバーA"
         conversationId="conv-1"
-      />,
+      /></ToastProvider>,
     );
 
     fireEvent.click(screen.getByText("編集"));
@@ -88,11 +89,11 @@ describe("ChatMessage", () => {
 
   it("returns to view mode when cancel is clicked", () => {
     render(
-      <ChatMessage
+      <ToastProvider><ChatMessage
         record={textRecord}
         participantName="メンバーA"
         conversationId="conv-1"
-      />,
+      /></ToastProvider>,
     );
 
     fireEvent.click(screen.getByText("編集"));
@@ -103,11 +104,11 @@ describe("ChatMessage", () => {
 
   it("does not show edit button for non-text records", () => {
     render(
-      <ChatMessage
+      <ToastProvider><ChatMessage
         record={imageRecord}
         participantName="メンバーA"
         conversationId="conv-1"
-      />,
+      /></ToastProvider>,
     );
 
     expect(screen.queryByText("編集")).not.toBeInTheDocument();
@@ -115,11 +116,11 @@ describe("ChatMessage", () => {
 
   it("shows delete button for all record types", () => {
     render(
-      <ChatMessage
+      <ToastProvider><ChatMessage
         record={imageRecord}
         participantName="メンバーA"
         conversationId="conv-1"
-      />,
+      /></ToastProvider>,
     );
 
     expect(screen.getByText("削除")).toBeInTheDocument();
@@ -127,11 +128,11 @@ describe("ChatMessage", () => {
 
   it("has data-record-id attribute", () => {
     const { container } = render(
-      <ChatMessage
+      <ToastProvider><ChatMessage
         record={textRecord}
         participantName="メンバーA"
         conversationId="conv-1"
-      />,
+      /></ToastProvider>,
     );
 
     expect(

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -8,6 +8,8 @@ import {
   type ActionState,
 } from "@/app/(app)/conversations/[id]/actions";
 import { formatTimeJst } from "@/lib/dateTime";
+import { FormError } from "@/components/FormError";
+import { useToast } from "@/components/ToastProvider";
 import type { Record } from "@/types/domain";
 import type { MediaUrl } from "@/usecases/recordUseCases";
 
@@ -66,6 +68,7 @@ export function ChatMessage({
 }: ChatMessageProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [isDeleting, startDeleteTransition] = useTransition();
+  const { addToast } = useToast();
 
   const [state, formAction, isPending] = useActionState<ActionState, FormData>(
     async (_prevState, formData) => {
@@ -86,7 +89,10 @@ export function ChatMessage({
   function handleDelete() {
     if (!window.confirm("このレコードを削除しますか？")) return;
     startDeleteTransition(async () => {
-      await deleteRecordAction(conversationId, record.id);
+      const result = await deleteRecordAction(conversationId, record.id);
+      if (result?.error) {
+        addToast(result.error, "error");
+      }
     });
   }
 
@@ -134,9 +140,7 @@ export function ChatMessage({
                   className="mt-1 block w-full rounded border border-gray-300 px-2 py-1 text-sm"
                 />
               </div>
-              {state?.error && (
-                <p className="text-xs text-red-600">{state.error}</p>
-              )}
+              <FormError message={state?.error} />
               <div className="flex gap-2">
                 <button
                   type="submit"

--- a/src/components/ChatView.test.tsx
+++ b/src/components/ChatView.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import { ChatView } from "./ChatView";
+import { ToastProvider } from "./ToastProvider";
 import type { ConversationWithRecords } from "@/usecases/conversationUseCases";
 
 vi.mock("next/navigation", () => ({
@@ -76,20 +77,20 @@ const conversation: ConversationWithRecords = {
 
 describe("ChatView", () => {
   it("renders conversation title in header", () => {
-    render(<ChatView conversation={conversation} mediaUrls={{}} />);
+    render(<ToastProvider><ChatView conversation={conversation} mediaUrls={{}} /></ToastProvider>);
 
     expect(screen.getByText("テスト会話")).toBeInTheDocument();
   });
 
   it("renders record content", () => {
-    render(<ChatView conversation={conversation} mediaUrls={{}} />);
+    render(<ToastProvider><ChatView conversation={conversation} mediaUrls={{}} /></ToastProvider>);
 
     expect(screen.getByText("最初のメッセージ")).toBeInTheDocument();
     expect(screen.getByText("二番目のメッセージ")).toBeInTheDocument();
   });
 
   it("renders participant name with messages", () => {
-    render(<ChatView conversation={conversation} mediaUrls={{}} />);
+    render(<ToastProvider><ChatView conversation={conversation} mediaUrls={{}} /></ToastProvider>);
 
     const participantLabels = screen.getAllByText("メンバーA");
     expect(participantLabels.length).toBeGreaterThan(0);
@@ -97,7 +98,7 @@ describe("ChatView", () => {
 
   it("shows empty state when no records", () => {
     const emptyConversation = { ...conversation, records: [] };
-    render(<ChatView conversation={emptyConversation} mediaUrls={{}} />);
+    render(<ToastProvider><ChatView conversation={emptyConversation} mediaUrls={{}} /></ToastProvider>);
 
     expect(
       screen.getByText("トークレコードがまだありません。"),
@@ -105,7 +106,7 @@ describe("ChatView", () => {
   });
 
   it("shows search bar when search button is clicked", () => {
-    render(<ChatView conversation={conversation} mediaUrls={{}} />);
+    render(<ToastProvider><ChatView conversation={conversation} mediaUrls={{}} /></ToastProvider>);
 
     fireEvent.click(screen.getByLabelText("検索"));
 
@@ -115,7 +116,7 @@ describe("ChatView", () => {
   });
 
   it("shows search results count", () => {
-    render(<ChatView conversation={conversation} mediaUrls={{}} />);
+    render(<ToastProvider><ChatView conversation={conversation} mediaUrls={{}} /></ToastProvider>);
 
     fireEvent.click(screen.getByLabelText("検索"));
     fireEvent.change(screen.getByPlaceholderText("会話内を検索"), {
@@ -126,7 +127,7 @@ describe("ChatView", () => {
   });
 
   it("shows no match message", () => {
-    render(<ChatView conversation={conversation} mediaUrls={{}} />);
+    render(<ToastProvider><ChatView conversation={conversation} mediaUrls={{}} /></ToastProvider>);
 
     fireEvent.click(screen.getByLabelText("検索"));
     fireEvent.change(screen.getByPlaceholderText("会話内を検索"), {
@@ -137,7 +138,7 @@ describe("ChatView", () => {
   });
 
   it("shows overflow menu when menu button is clicked", () => {
-    render(<ChatView conversation={conversation} mediaUrls={{}} />);
+    render(<ToastProvider><ChatView conversation={conversation} mediaUrls={{}} /></ToastProvider>);
 
     fireEvent.click(screen.getByLabelText("メニュー"));
 
@@ -158,20 +159,20 @@ describe("ChatView", () => {
   });
 
   it("renders back link", () => {
-    render(<ChatView conversation={conversation} mediaUrls={{}} />);
+    render(<ToastProvider><ChatView conversation={conversation} mediaUrls={{}} /></ToastProvider>);
 
     expect(screen.getByLabelText("戻る")).toBeInTheDocument();
   });
 
   it("renders composer", () => {
-    render(<ChatView conversation={conversation} mediaUrls={{}} />);
+    render(<ToastProvider><ChatView conversation={conversation} mediaUrls={{}} /></ToastProvider>);
 
     expect(screen.getByText("テキスト")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "追加" })).toBeInTheDocument();
   });
 
   it("opens date search modal from overflow menu", () => {
-    render(<ChatView conversation={conversation} mediaUrls={{}} />);
+    render(<ToastProvider><ChatView conversation={conversation} mediaUrls={{}} /></ToastProvider>);
 
     fireEvent.click(screen.getByLabelText("メニュー"));
     fireEvent.click(screen.getByRole("button", { name: "日付検索" }));
@@ -181,7 +182,7 @@ describe("ChatView", () => {
   });
 
   it("filters records by selected date in the modal", () => {
-    render(<ChatView conversation={conversation} mediaUrls={{}} />);
+    render(<ToastProvider><ChatView conversation={conversation} mediaUrls={{}} /></ToastProvider>);
 
     fireEvent.click(screen.getByLabelText("メニュー"));
     fireEvent.click(screen.getByRole("button", { name: "日付検索" }));

--- a/src/components/ConversationActions.test.tsx
+++ b/src/components/ConversationActions.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ConversationActions } from "./ConversationActions";
+import { ToastProvider } from "./ToastProvider";
 import type { ConversationWithMetadata } from "@/usecases/conversationUseCases";
 
 vi.mock("@/app/(app)/conversations/[id]/actions", () => ({
@@ -40,7 +41,7 @@ const conversation: ConversationWithMetadata = {
 
 describe("ConversationActions", () => {
   it("renders header with edit and delete buttons", () => {
-    render(<ConversationActions conversation={conversation} />);
+    render(<ToastProvider><ConversationActions conversation={conversation} /></ToastProvider>);
 
     expect(screen.getByText("テスト会話")).toBeInTheDocument();
     expect(screen.getByText("編集")).toBeInTheDocument();
@@ -48,7 +49,7 @@ describe("ConversationActions", () => {
   });
 
   it("switches to edit form when edit button is clicked", () => {
-    render(<ConversationActions conversation={conversation} />);
+    render(<ToastProvider><ConversationActions conversation={conversation} /></ToastProvider>);
 
     fireEvent.click(screen.getByText("編集"));
 
@@ -61,7 +62,7 @@ describe("ConversationActions", () => {
   });
 
   it("returns to header view when cancel is clicked", () => {
-    render(<ConversationActions conversation={conversation} />);
+    render(<ToastProvider><ConversationActions conversation={conversation} /></ToastProvider>);
 
     fireEvent.click(screen.getByText("編集"));
     fireEvent.click(screen.getByRole("button", { name: "キャンセル" }));

--- a/src/components/DeleteConversationButton.tsx
+++ b/src/components/DeleteConversationButton.tsx
@@ -2,6 +2,7 @@
 
 import { useTransition } from "react";
 import { deleteConversationAction } from "@/app/(app)/conversations/[id]/actions";
+import { useToast } from "@/components/ToastProvider";
 
 type DeleteConversationButtonProps = {
   conversationId: string;
@@ -11,6 +12,7 @@ export function DeleteConversationButton({
   conversationId,
 }: DeleteConversationButtonProps) {
   const [isPending, startTransition] = useTransition();
+  const { addToast } = useToast();
 
   function handleDelete() {
     if (!window.confirm("この会話を削除しますか？関連するレコードもすべて削除されます。")) {
@@ -18,7 +20,10 @@ export function DeleteConversationButton({
     }
 
     startTransition(async () => {
-      await deleteConversationAction(conversationId);
+      const result = await deleteConversationAction(conversationId);
+      if (result?.error) {
+        addToast(result.error, "error");
+      }
     });
   }
 

--- a/src/components/EditConversationForm.tsx
+++ b/src/components/EditConversationForm.tsx
@@ -6,6 +6,7 @@ import {
   type ActionState,
 } from "@/app/(app)/conversations/[id]/actions";
 import { ActivePeriodFields } from "@/components/ActivePeriodFields";
+import { FormError } from "@/components/FormError";
 import { ParticipantFields } from "@/components/ParticipantFields";
 import type { ConversationWithMetadata } from "@/usecases/conversationUseCases";
 import type {
@@ -103,9 +104,7 @@ export function EditConversationForm({
         value={JSON.stringify(participants)}
       />
 
-      {state?.error && (
-        <p className="text-sm text-red-600">{state.error}</p>
-      )}
+      <FormError message={state?.error} />
 
       <div className="flex gap-2">
         <button

--- a/src/components/EditableRecordCard.test.tsx
+++ b/src/components/EditableRecordCard.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { EditableRecordCard } from "./EditableRecordCard";
+import { ToastProvider } from "./ToastProvider";
 import type { Record } from "@/types/domain";
 
 vi.mock("@/app/(app)/conversations/[id]/actions", () => ({
@@ -31,7 +32,7 @@ const imageRecord: Record = {
 describe("EditableRecordCard", () => {
   it("renders record with edit and delete buttons for text records", () => {
     render(
-      <EditableRecordCard record={textRecord} conversationId="conv-1" />,
+      <ToastProvider><EditableRecordCard record={textRecord} conversationId="conv-1" /></ToastProvider>,
     );
 
     expect(screen.getByText("テストタイトル")).toBeInTheDocument();
@@ -42,7 +43,7 @@ describe("EditableRecordCard", () => {
 
   it("does not show edit button for non-text records", () => {
     render(
-      <EditableRecordCard record={imageRecord} conversationId="conv-1" />,
+      <ToastProvider><EditableRecordCard record={imageRecord} conversationId="conv-1" /></ToastProvider>,
     );
 
     expect(screen.queryByText("編集")).not.toBeInTheDocument();
@@ -51,7 +52,7 @@ describe("EditableRecordCard", () => {
 
   it("switches to edit form when edit button is clicked", () => {
     render(
-      <EditableRecordCard record={textRecord} conversationId="conv-1" />,
+      <ToastProvider><EditableRecordCard record={textRecord} conversationId="conv-1" /></ToastProvider>,
     );
 
     fireEvent.click(screen.getByText("編集"));
@@ -66,7 +67,7 @@ describe("EditableRecordCard", () => {
 
   it("populates edit form with current values", () => {
     render(
-      <EditableRecordCard record={textRecord} conversationId="conv-1" />,
+      <ToastProvider><EditableRecordCard record={textRecord} conversationId="conv-1" /></ToastProvider>,
     );
 
     fireEvent.click(screen.getByText("編集"));
@@ -77,7 +78,7 @@ describe("EditableRecordCard", () => {
 
   it("returns to view mode when cancel is clicked", () => {
     render(
-      <EditableRecordCard record={textRecord} conversationId="conv-1" />,
+      <ToastProvider><EditableRecordCard record={textRecord} conversationId="conv-1" /></ToastProvider>,
     );
 
     fireEvent.click(screen.getByText("編集"));

--- a/src/components/EditableRecordCard.tsx
+++ b/src/components/EditableRecordCard.tsx
@@ -6,7 +6,9 @@ import {
   deleteRecordAction,
   type ActionState,
 } from "@/app/(app)/conversations/[id]/actions";
+import { FormError } from "@/components/FormError";
 import { RecordCard } from "@/components/RecordCard";
+import { useToast } from "@/components/ToastProvider";
 import type { Record } from "@/types/domain";
 import type { MediaUrl } from "@/usecases/recordUseCases";
 
@@ -23,6 +25,7 @@ export function EditableRecordCard({
 }: EditableRecordCardProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [isDeleting, startDeleteTransition] = useTransition();
+  const { addToast } = useToast();
 
   const [state, formAction, isPending] = useActionState<ActionState, FormData>(
     async (_prevState, formData) => {
@@ -46,7 +49,10 @@ export function EditableRecordCard({
     }
 
     startDeleteTransition(async () => {
-      await deleteRecordAction(conversationId, record.id);
+      const result = await deleteRecordAction(conversationId, record.id);
+      if (result?.error) {
+        addToast(result.error, "error");
+      }
     });
   }
 
@@ -87,9 +93,7 @@ export function EditableRecordCard({
             />
           </div>
 
-          {state?.error && (
-            <p className="text-sm text-red-600">{state.error}</p>
-          )}
+          <FormError message={state?.error} />
 
           <div className="flex gap-2">
             <button

--- a/src/components/FormError.test.tsx
+++ b/src/components/FormError.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FormError } from "./FormError";
+
+describe("FormError", () => {
+  it("renders nothing when message is undefined", () => {
+    const { container } = render(<FormError />);
+    expect(container.firstElementChild).toBeNull();
+  });
+
+  it("renders nothing when message is empty string", () => {
+    const { container } = render(<FormError message="" />);
+    expect(container.firstElementChild).toBeNull();
+  });
+
+  it("renders alert with message", () => {
+    render(<FormError message="エラーが発生しました" />);
+    const alert = screen.getByRole("alert");
+    expect(alert).toBeDefined();
+    expect(alert.textContent).toContain("エラーが発生しました");
+  });
+});

--- a/src/components/FormError.tsx
+++ b/src/components/FormError.tsx
@@ -1,0 +1,31 @@
+type FormErrorProps = {
+  message?: string;
+};
+
+export function FormError({ message }: FormErrorProps) {
+  if (!message) {
+    return null;
+  }
+
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-2 rounded-md border border-red-200 bg-red-50 px-3 py-2"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        className="mt-0.5 h-4 w-4 shrink-0 text-red-500"
+        aria-hidden="true"
+      >
+        <path
+          fillRule="evenodd"
+          d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-5a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0110 5zm0 10a1 1 0 100-2 1 1 0 000 2z"
+          clipRule="evenodd"
+        />
+      </svg>
+      <p className="text-sm text-red-700">{message}</p>
+    </div>
+  );
+}

--- a/src/components/LogoutButton.test.tsx
+++ b/src/components/LogoutButton.test.tsx
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { LogoutButton } from "./LogoutButton";
+
+const { logoutMock, useActionStateMock } = vi.hoisted(() => ({
+  logoutMock: vi.fn(),
+  useActionStateMock: vi.fn(),
+}));
+
+vi.mock("react", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react");
+  return {
+    ...actual,
+    useActionState: useActionStateMock,
+  };
+});
+
+vi.mock("@/app/login/actions", () => ({
+  logout: logoutMock,
+}));
+
+describe("LogoutButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useActionStateMock.mockReturnValue([undefined, vi.fn(), false]);
+  });
+
+  it("renders logout button", () => {
+    render(<LogoutButton />);
+
+    expect(
+      screen.getByRole("button", { name: "ログアウト" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error message when action state contains error", () => {
+    useActionStateMock.mockReturnValue([
+      {
+        error: "ログアウトに失敗しました。時間をおいて再度お試しください。",
+      },
+      vi.fn(),
+      false,
+    ]);
+
+    render(<LogoutButton />);
+
+    expect(
+      screen.getByText(
+        "ログアウトに失敗しました。時間をおいて再度お試しください。",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/LogoutButton.tsx
+++ b/src/components/LogoutButton.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useActionState } from "react";
+import { logout } from "@/app/login/actions";
+import { FormError } from "@/components/FormError";
+
+type LogoutState =
+  | {
+      error: string;
+    }
+  | undefined;
+
+export function LogoutButton() {
+  const [state, formAction, isPending] = useActionState<LogoutState, FormData>(
+    async () => logout(),
+    undefined,
+  );
+
+  return (
+    <form action={formAction} className="mt-2 space-y-2">
+      <button
+        type="submit"
+        disabled={isPending}
+        className="w-full rounded border border-gray-300 px-3 py-1.5 text-xs text-gray-600 hover:bg-gray-100 disabled:opacity-50"
+      >
+        {isPending ? "ログアウト中..." : "ログアウト"}
+      </button>
+      <FormError message={state?.error} />
+    </form>
+  );
+}

--- a/src/components/NewConversationForm.tsx
+++ b/src/components/NewConversationForm.tsx
@@ -6,6 +6,7 @@ import {
   type CreateConversationState,
 } from "@/app/(app)/conversations/new/actions";
 import { ActivePeriodFields } from "@/components/ActivePeriodFields";
+import { FormError } from "@/components/FormError";
 import { ParticipantFields } from "@/components/ParticipantFields";
 import type {
   ConversationActivePeriodInput,
@@ -80,9 +81,7 @@ export function NewConversationForm() {
         value={JSON.stringify(participants)}
       />
 
-      {state?.error && (
-        <p className="text-sm text-red-600">{state.error}</p>
-      )}
+      <FormError message={state?.error} />
 
       <button
         type="submit"

--- a/src/components/RecordTimeline.test.tsx
+++ b/src/components/RecordTimeline.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { RecordTimeline } from "./RecordTimeline";
+import { ToastProvider } from "./ToastProvider";
 import type { Record } from "@/types/domain";
 
 vi.mock("@/app/(app)/conversations/[id]/actions", () => ({
@@ -24,7 +25,7 @@ const baseRecord: Record = {
 
 describe("RecordTimeline", () => {
   it("renders empty state when no records", () => {
-    render(<RecordTimeline records={[]} conversationId="conv-1" />);
+    render(<ToastProvider><RecordTimeline records={[]} conversationId="conv-1" /></ToastProvider>);
 
     expect(
       screen.getByText("トークレコードがまだありません。"),
@@ -42,7 +43,7 @@ describe("RecordTimeline", () => {
         position: 1,
       },
     ];
-    render(<RecordTimeline records={records} conversationId="conv-1" />);
+    render(<ToastProvider><RecordTimeline records={records} conversationId="conv-1" /></ToastProvider>);
 
     expect(screen.getByText("最初のトーク")).toBeInTheDocument();
     expect(screen.getByText("こんにちは")).toBeInTheDocument();

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { logout } from "@/app/login/actions";
+import { LogoutButton } from "@/components/LogoutButton";
 
 type SidebarProps = {
   userEmail: string;
@@ -37,14 +37,7 @@ export function Sidebar({ userEmail }: SidebarProps) {
 
       <div className="border-t border-gray-200 p-4">
         <p className="truncate text-xs text-gray-500">{userEmail}</p>
-        <form action={logout} className="mt-2">
-          <button
-            type="submit"
-            className="w-full rounded border border-gray-300 px-3 py-1.5 text-xs text-gray-600 hover:bg-gray-100"
-          >
-            ログアウト
-          </button>
-        </form>
+        <LogoutButton />
       </div>
     </aside>
   );

--- a/src/components/Skeleton.test.tsx
+++ b/src/components/Skeleton.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { Skeleton } from "./Skeleton";
+
+describe("Skeleton", () => {
+  it("renders with default classes", () => {
+    const { container } = render(<Skeleton />);
+    const el = container.firstElementChild!;
+    expect(el.className).toContain("animate-pulse");
+    expect(el.className).toContain("bg-gray-200");
+    expect(el.className).toContain("rounded");
+  });
+
+  it("applies additional className", () => {
+    const { container } = render(<Skeleton className="h-8 w-32" />);
+    const el = container.firstElementChild!;
+    expect(el.className).toContain("h-8");
+    expect(el.className).toContain("w-32");
+  });
+
+  it("is hidden from accessibility tree", () => {
+    const { container } = render(<Skeleton />);
+    const el = container.firstElementChild!;
+    expect(el.getAttribute("aria-hidden")).toBe("true");
+  });
+});

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,0 +1,12 @@
+type SkeletonProps = {
+  className?: string;
+};
+
+export function Skeleton({ className = "" }: SkeletonProps) {
+  return (
+    <div
+      className={`animate-pulse rounded bg-gray-200 ${className}`}
+      aria-hidden="true"
+    />
+  );
+}

--- a/src/components/Toast.test.tsx
+++ b/src/components/Toast.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Toast } from "./Toast";
+
+describe("Toast", () => {
+  it("renders message with error styling", () => {
+    const onDismiss = vi.fn();
+    render(
+      <Toast
+        id="t1"
+        message="エラーが発生しました"
+        type="error"
+        onDismiss={onDismiss}
+      />,
+    );
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toContain("エラーが発生しました");
+    expect(alert.className).toContain("border-red-200");
+  });
+
+  it("renders message with success styling", () => {
+    const onDismiss = vi.fn();
+    render(
+      <Toast
+        id="t2"
+        message="保存しました"
+        type="success"
+        onDismiss={onDismiss}
+      />,
+    );
+    const alert = screen.getByRole("alert");
+    expect(alert.className).toContain("border-green-200");
+  });
+
+  it("calls onDismiss when close button is clicked", () => {
+    const onDismiss = vi.fn();
+    render(
+      <Toast
+        id="t3"
+        message="テスト"
+        type="success"
+        onDismiss={onDismiss}
+      />,
+    );
+    const closeButton = screen.getByLabelText("閉じる");
+    fireEvent.click(closeButton);
+    expect(onDismiss).toHaveBeenCalledWith("t3");
+  });
+});

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,41 @@
+type ToastType = "success" | "error";
+
+type ToastProps = {
+  id: string;
+  message: string;
+  type: ToastType;
+  onDismiss: (id: string) => void;
+};
+
+const typeStyles: Record<ToastType, string> = {
+  success:
+    "border-green-200 bg-green-50 text-green-800",
+  error:
+    "border-red-200 bg-red-50 text-red-800",
+};
+
+export function Toast({ id, message, type, onDismiss }: ToastProps) {
+  return (
+    <div
+      role="alert"
+      className={`flex items-center gap-2 rounded-lg border px-4 py-3 shadow-lg ${typeStyles[type]}`}
+    >
+      <p className="flex-1 text-sm">{message}</p>
+      <button
+        type="button"
+        onClick={() => onDismiss(id)}
+        className="shrink-0 text-current opacity-60 hover:opacity-100"
+        aria-label="閉じる"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          className="h-4 w-4"
+        >
+          <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/src/components/ToastProvider.test.tsx
+++ b/src/components/ToastProvider.test.tsx
@@ -87,6 +87,24 @@ describe("ToastProvider", () => {
     vi.useRealTimers();
   });
 
+  it("clears pending timers on unmount", () => {
+    vi.useFakeTimers();
+
+    const { unmount } = render(
+      <ToastProvider>
+        <TestConsumer />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByText("success"));
+    expect(vi.getTimerCount()).toBe(1);
+
+    unmount();
+    expect(vi.getTimerCount()).toBe(0);
+
+    vi.useRealTimers();
+  });
+
   it("throws when useToast is used outside provider", () => {
     function Orphan() {
       useToast();

--- a/src/components/ToastProvider.test.tsx
+++ b/src/components/ToastProvider.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { ToastProvider, useToast } from "./ToastProvider";
+
+function TestConsumer() {
+  const { addToast } = useToast();
+  return (
+    <div>
+      <button onClick={() => addToast("成功しました", "success")}>
+        success
+      </button>
+      <button onClick={() => addToast("失敗しました", "error")}>
+        error
+      </button>
+    </div>
+  );
+}
+
+describe("ToastProvider", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders children", () => {
+    render(
+      <ToastProvider>
+        <p>child</p>
+      </ToastProvider>,
+    );
+    expect(screen.getByText("child")).toBeDefined();
+  });
+
+  it("shows toast when addToast is called", () => {
+    render(
+      <ToastProvider>
+        <TestConsumer />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByText("success"));
+    expect(screen.getByText("成功しました")).toBeDefined();
+  });
+
+  it("shows error toast", () => {
+    render(
+      <ToastProvider>
+        <TestConsumer />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByText("error"));
+    expect(screen.getByText("失敗しました")).toBeDefined();
+  });
+
+  it("dismisses toast when close button clicked", () => {
+    render(
+      <ToastProvider>
+        <TestConsumer />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByText("success"));
+    expect(screen.getByText("成功しました")).toBeDefined();
+
+    const closeButton = screen.getByLabelText("閉じる");
+    fireEvent.click(closeButton);
+    expect(screen.queryByText("成功しました")).toBeNull();
+  });
+
+  it("auto-dismisses toast after timeout", () => {
+    vi.useFakeTimers();
+
+    render(
+      <ToastProvider>
+        <TestConsumer />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByText("success"));
+    expect(screen.getByText("成功しました")).toBeDefined();
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(screen.queryByText("成功しました")).toBeNull();
+
+    vi.useRealTimers();
+  });
+
+  it("throws when useToast is used outside provider", () => {
+    function Orphan() {
+      useToast();
+      return null;
+    }
+
+    expect(() => render(<Orphan />)).toThrow(
+      "useToast must be used within a ToastProvider",
+    );
+  });
+});

--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -4,9 +4,10 @@ import {
   createContext,
   useCallback,
   useContext,
-  useSyncExternalStore,
+  useEffect,
   useRef,
   useState,
+  useSyncExternalStore,
 } from "react";
 import { createPortal } from "react-dom";
 import { Toast } from "@/components/Toast";
@@ -46,6 +47,17 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(
     new Map(),
   );
+
+  useEffect(() => {
+    const timers = timersRef.current;
+
+    return () => {
+      for (const timer of timers.values()) {
+        clearTimeout(timer);
+      }
+      timers.clear();
+    };
+  }, []);
 
   const dismiss = useCallback((id: string) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));

--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useSyncExternalStore,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+import { Toast } from "@/components/Toast";
+
+type ToastType = "success" | "error";
+
+type ToastItem = {
+  id: string;
+  message: string;
+  type: ToastType;
+};
+
+type ToastContextValue = {
+  addToast: (message: string, type: ToastType) => void;
+};
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const MAX_TOASTS = 3;
+const AUTO_DISMISS_MS = 5000;
+
+const subscribe = () => () => {};
+const getSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+export function useToast(): ToastContextValue {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+  return context;
+}
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const isMounted = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+    new Map(),
+  );
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+    const timer = timersRef.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      timersRef.current.delete(id);
+    }
+  }, []);
+
+  const addToast = useCallback(
+    (message: string, type: ToastType) => {
+      const id = crypto.randomUUID();
+      setToasts((prev) => {
+        const next = [...prev, { id, message, type }];
+        if (next.length > MAX_TOASTS) {
+          const removed = next[0];
+          const timer = timersRef.current.get(removed.id);
+          if (timer) {
+            clearTimeout(timer);
+            timersRef.current.delete(removed.id);
+          }
+          return next.slice(1);
+        }
+        return next;
+      });
+
+      const timer = setTimeout(() => {
+        dismiss(id);
+      }, AUTO_DISMISS_MS);
+      timersRef.current.set(id, timer);
+    },
+    [dismiss],
+  );
+
+  return (
+    <ToastContext.Provider value={{ addToast }}>
+      {children}
+      {isMounted &&
+        createPortal(
+          <div className="fixed right-4 top-4 z-50 flex w-80 flex-col gap-2">
+            {toasts.map((toast) => (
+              <Toast
+                key={toast.id}
+                id={toast.id}
+                message={toast.message}
+                type={toast.type}
+                onDismiss={dismiss}
+              />
+            ))}
+          </div>,
+          document.body,
+        )}
+    </ToastContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary

- `error.tsx`（ルート + appグループ）でグローバルエラーバウンダリを追加し、予期しないエラーをキャッチ・表示
- `loading.tsx`（会話一覧・チャットビュー・検索）でスケルトンUIを追加し、ページ遷移時のローディング体験を向上
- トースト通知システム（`ToastProvider` + `Toast`）を外部ライブラリ不使用で自作実装（success/error、5秒自動消去、最大3件）
- `FormError` コンポーネントでフォームエラー表示を統一（`role="alert"` + 警告アイコン付き）
- 全 Server Action の usecase 呼び出しに try/catch を追加し、ユーザー向けエラーメッセージを返すように変更
- 削除操作（会話・レコード）の失敗時にトーストでエラーフィードバックを表示

### 新規ファイル（13件）

| ファイル | 内容 |
|---|---|
| `src/components/Skeleton.tsx` | 再利用可能なスケルトンプリミティブ |
| `src/components/FormError.tsx` | 統一フォームエラー表示 |
| `src/components/Toast.tsx` | トースト通知コンポーネント |
| `src/components/ToastProvider.tsx` | トースト Context + Portal |
| `src/app/error.tsx` | ルートエラーバウンダリ |
| `src/app/(app)/error.tsx` | アプリグループエラーバウンダリ |
| `src/app/(app)/loading.tsx` | 会話一覧スケルトン |
| `src/app/(app)/conversations/[id]/loading.tsx` | チャットビュースケルトン |
| `src/app/(app)/search/loading.tsx` | 検索ページスケルトン |
| テストファイル×4 | Skeleton, FormError, Toast, ToastProvider |

### 変更ファイル（18件）

- Server Actions 3ファイル: 全 usecase 呼び出しに try/catch 追加
- コンポーネント 8ファイル: FormError 採用 + delete 操作のトーストエラー表示
- レイアウト: ToastProvider 統合
- 既存テスト 5ファイル: ToastProvider ラッパー追加

## Test plan

- [x] `pnpm lint` — ESLint パス
- [x] `pnpm typecheck` — TypeScript パス
- [x] `pnpm test` — 全429テスト パス
- [x] `pnpm build` — プロダクションビルド パス
- [ ] 会話一覧ページ遷移時にスケルトンUIが表示されること
- [ ] チャットビューページ遷移時にスケルトンUIが表示されること
- [ ] Supabase接続エラー時にエラーバウンダリが表示されること
- [ ] フォーム送信エラー時に FormError が表示されること
- [ ] 削除操作失敗時にトースト通知が表示されること
- [ ] トーストが5秒後に自動消去されること

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)