### PR TITLE
feat: メッセージ日時を条件付き年表示にする

### DIFF
--- a/src/components/ChatMessage.test.tsx
+++ b/src/components/ChatMessage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import { ChatMessage } from "./ChatMessage";
 import { ToastProvider } from "./ToastProvider";
@@ -30,6 +30,10 @@ const imageRecord: Record = {
 };
 
 describe("ChatMessage", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("renders participant name and initial", () => {
     render(
       <ToastProvider><ChatMessage
@@ -58,7 +62,10 @@ describe("ChatMessage", () => {
     expect(screen.getByText("テスト内容")).toBeInTheDocument();
   });
 
-  it("renders posted time", () => {
+  it("renders posted date time without year for current-year records", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-22T00:00:00Z"));
+
     render(
       <ToastProvider><ChatMessage
         record={textRecord}
@@ -68,7 +75,7 @@ describe("ChatMessage", () => {
       /></ToastProvider>,
     );
 
-    expect(screen.getByText("19:30")).toBeInTheDocument();
+    expect(screen.getByText("01/15(木) 19:30")).toBeInTheDocument();
   });
 
   it("switches to edit form when edit button is clicked", () => {

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -7,7 +7,7 @@ import {
   deleteRecordAction,
   type ActionState,
 } from "@/app/(app)/conversations/[id]/actions";
-import { formatTimeJst } from "@/lib/dateTime";
+import { formatMessageDateTimeJst } from "@/lib/dateTime";
 import { FormError } from "@/components/FormError";
 import { useToast } from "@/components/ToastProvider";
 import type { Record } from "@/types/domain";
@@ -193,7 +193,7 @@ export const ChatMessage = memo(function ChatMessage({
         </div>
         <div className="mt-0.5 flex items-center gap-2">
           <span className="text-[10px] text-gray-500">
-            {formatTimeJst(record.postedAt)}
+            {formatMessageDateTimeJst(record.postedAt)}
           </span>
           {isEditMode && (
             <>

--- a/src/components/DateSearchResults.test.tsx
+++ b/src/components/DateSearchResults.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { DateSearchResults } from "./DateSearchResults";
 import type { ConversationParticipant, Record } from "@/types/domain";
@@ -35,6 +35,10 @@ const baseRecord: Record = {
 };
 
 describe("DateSearchResults", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("shows empty message when no records", () => {
     render(
       <DateSearchResults
@@ -105,6 +109,23 @@ describe("DateSearchResults", () => {
     );
 
     expect(screen.getByText("メンバーA")).toBeInTheDocument();
+  });
+
+  it("renders posted date time without year for current-year records", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-22T00:00:00Z"));
+
+    render(
+      <DateSearchResults
+        conversationId="conv-1"
+        records={[baseRecord]}
+        participants={participants}
+        selectedDate="2026-01-01"
+        displayName=""
+      />,
+    );
+
+    expect(screen.getByText("01/01(木) 10:00")).toBeInTheDocument();
   });
 
   it("shows unknown for missing participant", () => {

--- a/src/components/DateSearchResults.tsx
+++ b/src/components/DateSearchResults.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { formatTimeJst } from "@/lib/dateTime";
+import { formatMessageDateTimeJst } from "@/lib/dateTime";
 import type { ConversationParticipant, Record, RecordType } from "@/types/domain";
 import { replaceMyNamePlaceholder } from "@/usecases/contentTransform";
 
@@ -62,7 +62,7 @@ export function DateSearchResults({
                   {recordTypeLabels[record.recordType]}
                 </span>
                 <span className="text-xs text-gray-500">
-                  {formatTimeJst(record.postedAt)}
+                  {formatMessageDateTimeJst(record.postedAt)}
                 </span>
                 <span className="text-xs text-gray-500">
                   {participantMap.get(record.speakerParticipantId) ?? "不明"}

--- a/src/lib/dateTime.test.ts
+++ b/src/lib/dateTime.test.ts
@@ -3,6 +3,7 @@ import {
   formatDateHeaderJst,
   formatDateJst,
   formatDateTimeJst,
+  formatMessageDateTimeJst,
   formatTimeJst,
   getDateKeyJst,
 } from "./dateTime";
@@ -20,6 +21,33 @@ describe("dateTime", () => {
     expect(formatDateTimeJst("2026-01-15T10:30:00Z")).toBe(
       "2026/01/15 19:30",
     );
+  });
+
+  it("formats current-year message date time without year in JST", () => {
+    expect(
+      formatMessageDateTimeJst(
+        "2026-04-22T05:30:00Z",
+        new Date("2026-01-01T00:00:00Z"),
+      ),
+    ).toBe("04/22(水) 14:30");
+  });
+
+  it("formats non-current-year message date time with year in JST", () => {
+    expect(
+      formatMessageDateTimeJst(
+        "2025-04-22T05:30:00Z",
+        new Date("2026-01-01T00:00:00Z"),
+      ),
+    ).toBe("2025/04/22(火) 14:30");
+  });
+
+  it("compares current year in JST", () => {
+    expect(
+      formatMessageDateTimeJst(
+        "2026-01-01T00:30:00+09:00",
+        new Date("2025-12-31T15:30:00Z"),
+      ),
+    ).toBe("01/01(木) 00:30");
   });
 
   it("formats date header in JST", () => {

--- a/src/lib/dateTime.ts
+++ b/src/lib/dateTime.ts
@@ -23,6 +23,16 @@ const dateTimeFormatter = createFormatter({
   minute: "2-digit",
 });
 
+const messageDateTimeFormatter = createFormatter({
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  weekday: "short",
+  hour: "2-digit",
+  minute: "2-digit",
+  hourCycle: "h23",
+});
+
 const timeFormatter = createFormatter({
   hour: "2-digit",
   minute: "2-digit",
@@ -47,6 +57,42 @@ export function formatDateJst(dateString: string): string {
 
 export function formatDateTimeJst(dateString: string): string {
   return dateTimeFormatter.format(new Date(dateString));
+}
+
+type MessageDateTimeParts = {
+  year: string;
+  month: string;
+  day: string;
+  weekday: string;
+  hour: string;
+  minute: string;
+};
+
+function getMessageDateTimeParts(date: Date): MessageDateTimeParts {
+  const parts = messageDateTimeFormatter.formatToParts(date);
+
+  return {
+    year: parts.find((part) => part.type === "year")?.value ?? "",
+    month: parts.find((part) => part.type === "month")?.value ?? "",
+    day: parts.find((part) => part.type === "day")?.value ?? "",
+    weekday: parts.find((part) => part.type === "weekday")?.value ?? "",
+    hour: parts.find((part) => part.type === "hour")?.value ?? "",
+    minute: parts.find((part) => part.type === "minute")?.value ?? "",
+  };
+}
+
+export function formatMessageDateTimeJst(
+  dateString: string,
+  currentDate: Date = new Date(),
+): string {
+  const target = getMessageDateTimeParts(new Date(dateString));
+  const current = getMessageDateTimeParts(currentDate);
+  const datePart =
+    target.year === current.year
+      ? `${target.month}/${target.day}(${target.weekday})`
+      : `${target.year}/${target.month}/${target.day}(${target.weekday})`;
+
+  return `${datePart} ${target.hour}:${target.minute}`;
 }
 
 export function formatTimeJst(dateString: string): string {


### PR DESCRIPTION
## Why / Background
- 長期間のトーク履歴で、各メッセージの時刻だけでは日付を判別しづらい
- メッセージ単位で日付+時刻を表示し、今年のメッセージは年を省略してコンパクトにする

## What / Summary
- `formatMessageDateTimeJst` を追加
  - 今年: `MM/DD(曜) HH:mm`
  - 今年以外: `YYYY/MM/DD(曜) HH:mm`
- `ChatMessage` と `DateSearchResults` の `formatTimeJst` 利用を新フォーマッターへ差し替え
- JSTで現在年を判定する単体テストと表示テストを追加

## Scope / Impact
- 影響する画面: 会話詳細、日付検索結果
- 影響しないもの: グローバル検索結果、メディアギャラリー、編集フォーム
- 破壊的変更: なし

## Related Issues
- Closes #94

## Test Plan
- [x] TDD red: 新フォーマッター未実装・既存時刻表示のまま失敗することを確認
- [x] `pnpm test src/lib/dateTime.test.ts src/components/ChatMessage.test.tsx src/components/DateSearchResults.test.tsx`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`（485件）
- [x] `pnpm build`

## Notes
- Issue例の曜日表記は、実際の日付からJSTで算出します。例: 2026/04/22 は水曜日として表示されます。