### PR TITLE
feat: モバイル閲覧時に ChatComposer を非表示にする

### DIFF
--- a/src/components/ChatView.test.tsx
+++ b/src/components/ChatView.test.tsx
@@ -170,6 +170,27 @@ describe("ChatView", () => {
     expect(screen.getByRole("button", { name: "追加" })).toBeInTheDocument();
   });
 
+  it("hides composer on mobile while not in edit mode and keeps it visible on desktop", () => {
+    render(<ToastProvider><ChatView conversation={conversation} mediaUrls={{}} displayName="" /></ToastProvider>);
+
+    expect(screen.getByTestId("chat-composer-container")).toHaveClass(
+      "hidden",
+      "sm:block",
+    );
+  });
+
+  it("shows composer on mobile when edit mode is enabled", () => {
+    render(<ToastProvider><ChatView conversation={conversation} mediaUrls={{}} displayName="" /></ToastProvider>);
+
+    fireEvent.click(screen.getByLabelText("メニュー"));
+    fireEvent.click(screen.getByRole("button", { name: "会話編集" }));
+
+    expect(screen.getByTestId("chat-composer-container")).toHaveClass("block");
+    expect(screen.getByTestId("chat-composer-container")).not.toHaveClass(
+      "hidden",
+    );
+  });
+
   it("opens date search modal from overflow menu", async () => {
     render(<ToastProvider><ChatView conversation={conversation} mediaUrls={{}} displayName="" /></ToastProvider>);
 

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -361,10 +361,15 @@ export function ChatView({ conversation, mediaUrls, displayName }: ChatViewProps
       </div>
 
       {/* Composer */}
-      <ChatComposer
-        conversationId={conversation.id}
-        participants={conversation.participants}
-      />
+      <div
+        data-testid="chat-composer-container"
+        className={isEditMode ? "block" : "hidden sm:block"}
+      >
+        <ChatComposer
+          conversationId={conversation.id}
+          participants={conversation.participants}
+        />
+      </div>
 
       <DateSearchModal
         conversationId={conversation.id}


### PR DESCRIPTION
## Why / Background
- モバイルでは ChatComposer が画面下部を占有し、閲覧領域が狭くなる
- 既存の編集モード切り替えを利用して、閲覧時は Composer を隠し、編集時だけ表示したい

## What / Summary
- `ChatComposer` を常時マウントしたまま、ラッパーの Tailwind クラスで表示を制御
  - 非編集時: `hidden sm:block`
  - 編集時: `block`
- `ChatView` のテストにモバイル非表示 / 編集時表示のクラス検証を追加

## Scope / Impact
- 影響する画面: 会話詳細
- 影響しないもの: デスクトップ表示、ChatComposer 自体のUI/フォーム挙動
- 破壊的変更: なし

## Related Issues
- Closes #95

## Test Plan
- [x] TDD red: `chat-composer-container` がなく表示制御テストが失敗することを確認
- [x] `pnpm test src/components/ChatView.test.tsx`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`（487件）
- [x] `pnpm build`

## Notes
- 案Aの CSS / Tailwind 制御で実装し、新規ライブラリは追加していません。
- Composer は条件レンダリングせず常時マウントするため、表示切替は CSS クラス変更のみです。