### PR TITLE
feat: モバイル会話一覧を3列コンパクト表示にする

### DIFF
--- a/src/components/ConversationCard.test.tsx
+++ b/src/components/ConversationCard.test.tsx
@@ -63,4 +63,30 @@ describe("ConversationCard", () => {
     expect(screen.getByText("No Image")).toBeInTheDocument();
     expect(screen.queryByRole("img")).not.toBeInTheDocument();
   });
+
+  it("uses compact mobile layout while preserving desktop card layout", () => {
+    render(<ConversationCard conversation={baseConversation} />);
+
+    expect(screen.getByRole("link")).toHaveClass(
+      "rounded-md",
+      "sm:rounded-lg",
+    );
+    expect(screen.getByTestId("conversation-card-thumbnail")).toHaveClass(
+      "aspect-square",
+      "sm:aspect-[16/9]",
+    );
+    expect(screen.getByTestId("conversation-card-title")).toHaveClass(
+      "truncate",
+      "text-xs",
+      "sm:text-sm",
+    );
+  });
+
+  it("keeps no-image placeholder inside square mobile thumbnail", () => {
+    render(<ConversationCard conversation={baseConversation} />);
+
+    expect(screen.getByTestId("conversation-card-thumbnail")).toContainElement(
+      screen.getByText("No Image"),
+    );
+  });
 });

--- a/src/components/ConversationCard.tsx
+++ b/src/components/ConversationCard.tsx
@@ -21,26 +21,34 @@ export const ConversationCard = memo(function ConversationCard({ conversation }:
   return (
     <Link
       href={`/conversations/${conversation.id}`}
-      className="block overflow-hidden rounded-lg border border-gray-200 hover:shadow-md"
+      className="block overflow-hidden rounded-md border border-gray-200 hover:shadow-md sm:rounded-lg"
     >
-      <div className="relative aspect-[16/9] bg-gray-100">
+      <div
+        data-testid="conversation-card-thumbnail"
+        className="relative aspect-square bg-gray-100 sm:aspect-[16/9]"
+      >
         {canRenderConversationCoverImage(conversation.coverImagePath) ? (
           <Image
             src={conversation.coverImagePath}
             alt={conversation.title}
             fill
-            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+            sizes="(max-width: 640px) 33vw, (max-width: 1024px) 50vw, 33vw"
             className="object-cover"
           />
         ) : (
-          <div className="flex h-full items-center justify-center text-2xl text-gray-400">
+          <div className="flex h-full items-center justify-center text-[10px] text-gray-400 sm:text-2xl">
             No Image
           </div>
         )}
       </div>
-      <div className="px-3 py-2">
-        <p className="truncate text-sm font-medium">{conversation.title}</p>
-        <p className="mt-0.5 text-xs text-gray-500">
+      <div className="px-1 py-1 sm:px-3 sm:py-2">
+        <p
+          data-testid="conversation-card-title"
+          className="truncate text-xs font-medium sm:text-sm"
+        >
+          {conversation.title}
+        </p>
+        <p className="hidden mt-0.5 text-xs text-gray-500 sm:block">
           {conversation.activeDays}日
         </p>
       </div>

--- a/src/components/GroupedConversationList.test.tsx
+++ b/src/components/GroupedConversationList.test.tsx
@@ -58,6 +58,16 @@ describe("GroupedConversationList", () => {
     expect(screen.queryByText("日向坂の会話")).not.toBeInTheDocument();
   });
 
+  it("uses a three-column mobile grid while preserving desktop columns", () => {
+    render(<GroupedConversationList conversations={conversations} />);
+
+    expect(screen.getByTestId("conversation-grid")).toHaveClass(
+      "grid-cols-3",
+      "sm:grid-cols-2",
+      "lg:grid-cols-3",
+    );
+  });
+
   it("switches to sakurazaka group on tab click", () => {
     render(<GroupedConversationList conversations={conversations} />);
 

--- a/src/components/GroupedConversationList.tsx
+++ b/src/components/GroupedConversationList.tsx
@@ -50,7 +50,10 @@ export function GroupedConversationList({
             このグループの会話はまだありません。
           </p>
         ) : (
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div
+            data-testid="conversation-grid"
+            className="grid grid-cols-3 gap-2 sm:grid-cols-2 sm:gap-4 lg:grid-cols-3"
+          >
             {filtered.map((conversation) => (
               <ConversationCard
                 key={conversation.id}


### PR DESCRIPTION
## Why / Background
- モバイルの会話一覧が1列フルカードで、一覧性が低くスクロール量が多い
- モバイルでは3列コンパクト表示にして、一画面あたりの会話数を増やす

## What / Summary
- `GroupedConversationList` のグリッドをレスポンシブ対応
  - モバイル: `grid-cols-3`
  - `sm` 以上: 既存同等の `sm:grid-cols-2 lg:grid-cols-3`
- `ConversationCard` のモバイル表示をコンパクト化
  - サムネイル: `aspect-square`、`sm` 以上は `aspect-[16/9]`
  - タイトル: モバイル `text-xs` + `truncate`、`sm` 以上は既存同等の `text-sm`
  - activeDays は `sm` 以上で表示し、モバイルでは省略
- 画像なしカードの placeholder も正方形サムネイル内に収まるよう調整

## Scope / Impact
- 影響する画面: 会話一覧
- 影響しないもの: 会話カードのリンク遷移、デスクトップの列数、データ取得
- 破壊的変更: なし

## Related Issues
- Closes #96

## Test Plan
- [x] TDD red: レスポンシブクラス / test id が未実装でテスト失敗を確認
- [x] `pnpm test src/components/ConversationCard.test.tsx src/components/GroupedConversationList.test.tsx`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`（490件）
- [x] `pnpm build`

## Notes
- 案Aの Tailwind レスポンシブクラスで実装し、新規ライブラリは追加していません。