### PR TITLE
feat: 日付入力を現在JSTで初期化する

### DIFF
--- a/src/components/ActivePeriodFields.test.tsx
+++ b/src/components/ActivePeriodFields.test.tsx
@@ -1,9 +1,13 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ActivePeriodFields } from "./ActivePeriodFields";
 import type { ConversationActivePeriodInput } from "@/usecases/conversationUseCases";
 
 describe("ActivePeriodFields", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("renders empty state when no periods", () => {
     render(<ActivePeriodFields periods={[]} onChange={vi.fn()} />);
 
@@ -20,7 +24,10 @@ describe("ActivePeriodFields", () => {
     expect(screen.getByDisplayValue("2026-06-30")).toBeInTheDocument();
   });
 
-  it("calls onChange with new period when add button is clicked", () => {
+  it("calls onChange with new period initialized to current JST date when add button is clicked", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-22T15:30:45Z"));
+
     const onChange = vi.fn();
     const periods: ConversationActivePeriodInput[] = [
       { startDate: "2026-01-01", endDate: null },
@@ -31,7 +38,7 @@ describe("ActivePeriodFields", () => {
 
     expect(onChange).toHaveBeenCalledWith([
       { startDate: "2026-01-01", endDate: null },
-      { startDate: "", endDate: null },
+      { startDate: "2026-04-23", endDate: null },
     ]);
   });
 

--- a/src/components/ActivePeriodFields.tsx
+++ b/src/components/ActivePeriodFields.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { getCurrentJstDate } from "@/lib/dateTime";
 import type { ConversationActivePeriodInput } from "@/usecases/conversationUseCases";
 
 type ActivePeriodFieldsProps = {
@@ -12,7 +13,7 @@ export function ActivePeriodFields({
   onChange,
 }: ActivePeriodFieldsProps) {
   function addPeriod() {
-    onChange([...periods, { startDate: "", endDate: null }]);
+    onChange([...periods, { startDate: getCurrentJstDate(), endDate: null }]);
   }
 
   function removePeriod(index: number) {

--- a/src/components/ChatComposer.test.tsx
+++ b/src/components/ChatComposer.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { act, render, screen, fireEvent } from "@testing-library/react";
 import { ChatComposer } from "./ChatComposer";
 import type { ConversationParticipant } from "@/types/domain";
 
@@ -161,6 +161,9 @@ describe("ChatComposer", () => {
         participants={singleParticipant}
       />,
     );
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
 
     expect(screen.getByLabelText("投稿日時")).toHaveValue(
       "2026-04-23T00:30",

--- a/src/components/ChatComposer.test.tsx
+++ b/src/components/ChatComposer.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ChatComposer } from "./ChatComposer";
 import type { ConversationParticipant } from "@/types/domain";
@@ -30,6 +30,10 @@ const twoParticipants: ConversationParticipant[] = [
 const singleParticipant: ConversationParticipant[] = [twoParticipants[0]];
 
 describe("ChatComposer", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("renders type tabs", () => {
     render(
       <ChatComposer
@@ -147,7 +151,10 @@ describe("ChatComposer", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows postedAt input", () => {
+  it("initializes postedAt input with current JST datetime", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-22T15:30:45Z"));
+
     render(
       <ChatComposer
         conversationId="conv-1"
@@ -155,11 +162,9 @@ describe("ChatComposer", () => {
       />,
     );
 
-    const dateInputs = screen.getAllByDisplayValue("");
-    const datetimeInput = dateInputs.find(
-      (el) => el.getAttribute("type") === "datetime-local",
+    expect(screen.getByLabelText("投稿日時")).toHaveValue(
+      "2026-04-23T00:30",
     );
-    expect(datetimeInput).toBeInTheDocument();
   });
 
   it("has submit button", () => {

--- a/src/components/ChatComposer.tsx
+++ b/src/components/ChatComposer.tsx
@@ -9,6 +9,7 @@ import {
   addAudioRecordAction,
   type ActionState,
 } from "@/app/(app)/conversations/[id]/actions";
+import { getCurrentJstDateTimeLocal } from "@/lib/dateTime";
 import { FormError } from "@/components/FormError";
 import type { ConversationParticipant, RecordType } from "@/types/domain";
 
@@ -186,6 +187,7 @@ export function ChatComposer({
               name="postedAt"
               type="datetime-local"
               required
+              defaultValue={getCurrentJstDateTimeLocal()}
               aria-label="投稿日時"
               className="block w-full rounded border border-gray-300 px-2 py-2 text-sm"
             />

--- a/src/components/ChatComposer.tsx
+++ b/src/components/ChatComposer.tsx
@@ -39,6 +39,7 @@ export function ChatComposer({
   const [speakerParticipantId, setSpeakerParticipantId] = useState(
     participants.length === 1 ? participants[0].id : "",
   );
+  const [postedAt, setPostedAt] = useState("");
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [clientError, setClientError] = useState<string | null>(null);
 
@@ -56,6 +57,7 @@ export function ChatComposer({
       const result = await action(conversationId, _prevState, formData);
       if (!result?.error) {
         formRef.current?.reset();
+        setPostedAt(getCurrentJstDateTimeLocal());
         setPreviewUrl(null);
         if (participants.length === 1) {
           setSpeakerParticipantId(participants[0].id);
@@ -73,6 +75,16 @@ export function ChatComposer({
       }
     };
   }, [previewUrl]);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setPostedAt(getCurrentJstDateTimeLocal());
+    }, 0);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, []);
 
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     setClientError(null);
@@ -187,7 +199,8 @@ export function ChatComposer({
               name="postedAt"
               type="datetime-local"
               required
-              defaultValue={getCurrentJstDateTimeLocal()}
+              value={postedAt}
+              onChange={(e) => setPostedAt(e.target.value)}
               aria-label="投稿日時"
               className="block w-full rounded border border-gray-300 px-2 py-2 text-sm"
             />

--- a/src/lib/dateTime.test.ts
+++ b/src/lib/dateTime.test.ts
@@ -1,14 +1,20 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   formatDateHeaderJst,
   formatDateJst,
   formatDateTimeJst,
   formatMessageDateTimeJst,
   formatTimeJst,
+  getCurrentJstDate,
+  getCurrentJstDateTimeLocal,
   getDateKeyJst,
 } from "./dateTime";
 
 describe("dateTime", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("formats time in JST", () => {
     expect(formatTimeJst("2026-01-15T10:30:00Z")).toBe("19:30");
   });
@@ -56,5 +62,19 @@ describe("dateTime", () => {
 
   it("builds date keys in JST", () => {
     expect(getDateKeyJst("2026-01-15T15:30:00Z")).toBe("2026-01-16");
+  });
+
+  it("returns current JST date time for datetime-local inputs", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-22T15:30:45Z"));
+
+    expect(getCurrentJstDateTimeLocal()).toBe("2026-04-23T00:30");
+  });
+
+  it("returns current JST date for date inputs", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-22T15:30:45Z"));
+
+    expect(getCurrentJstDate()).toBe("2026-04-23");
   });
 });

--- a/src/lib/dateTime.ts
+++ b/src/lib/dateTime.ts
@@ -1,4 +1,5 @@
 const JST_TIME_ZONE = "Asia/Tokyo";
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
 
 function createFormatter(
   options: Intl.DateTimeFormatOptions,
@@ -50,6 +51,28 @@ const dateKeyFormatter = createFormatter({
   month: "2-digit",
   day: "2-digit",
 });
+
+function padTwoDigits(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+function getJstDateInputParts(date: Date): {
+  year: number;
+  month: string;
+  day: string;
+  hour: string;
+  minute: string;
+} {
+  const jstDate = new Date(date.getTime() + JST_OFFSET_MS);
+
+  return {
+    year: jstDate.getUTCFullYear(),
+    month: padTwoDigits(jstDate.getUTCMonth() + 1),
+    day: padTwoDigits(jstDate.getUTCDate()),
+    hour: padTwoDigits(jstDate.getUTCHours()),
+    minute: padTwoDigits(jstDate.getUTCMinutes()),
+  };
+}
 
 export function formatDateJst(dateString: string): string {
   return dateFormatter.format(new Date(dateString));
@@ -105,4 +128,14 @@ export function formatDateHeaderJst(dateString: string): string {
 
 export function getDateKeyJst(dateString: string): string {
   return dateKeyFormatter.format(new Date(dateString)).replace(/\//g, "-");
+}
+
+export function getCurrentJstDateTimeLocal(currentDate = new Date()): string {
+  const parts = getJstDateInputParts(currentDate);
+  return `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}`;
+}
+
+export function getCurrentJstDate(currentDate = new Date()): string {
+  const parts = getJstDateInputParts(currentDate);
+  return `${parts.year}-${parts.month}-${parts.day}`;
 }


### PR DESCRIPTION
## Why / Background
- ChatComposer の投稿日時が空欄で、毎回手入力が必要だった
- ActivePeriodFields の新規期間追加でも開始日が空欄になっていた

## What / Summary
- `src/lib/dateTime.ts` に現在JST入力値フォーマッターを追加
  - `getCurrentJstDateTimeLocal()` → `YYYY-MM-DDTHH:mm`
  - `getCurrentJstDate()` → `YYYY-MM-DD`
- ChatComposer の `datetime-local` に現在JST日時を `defaultValue` として設定
- ActivePeriodFields の `addPeriod()` で開始日を今日のJST日付に設定
- JSTの日付またぎを含む単体テストとコンポーネントテストを追加

## Scope / Impact
- 影響する画面: 会話詳細の ChatComposer、新規/編集会話フォーム内の期間追加
- 影響しないもの: 既存保存済み期間、既存保存済みレコード、保存処理
- 破壊的変更: なし

## Related Issues
- Closes #100

## Test Plan
- [x] TDD red: 新フォーマッター未実装、入力初期値未設定で失敗することを確認
- [x] `pnpm test src/lib/dateTime.test.ts src/components/ChatComposer.test.tsx src/components/ActivePeriodFields.test.tsx`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`（492件）
- [x] `pnpm build`

## Notes
- JST は固定オフセット（UTC+09:00、DSTなし）として入力値用に整形しています。
- 新規ライブラリは追加していません。