### PR TITLE
feat: トーク画面の日時表示位置を変更

### DIFF
--- a/src/components/ChatMessage.test.tsx
+++ b/src/components/ChatMessage.test.tsx
@@ -94,6 +94,49 @@ describe("ChatMessage", () => {
     expect(screen.getByText("01/15(木) 19:30")).toBeInTheDocument();
   });
 
+  it("renders posted date time inline with participant name", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-22T00:00:00Z"));
+
+    render(
+      <ToastProvider><ChatMessage
+        record={textRecord}
+        participantName="メンバーA"
+        conversationId="conv-1"
+        displayName=""
+      /></ToastProvider>,
+    );
+
+    const metaRow = screen.getByTestId("message-meta-row");
+    expect(metaRow).toHaveClass("flex", "items-baseline", "gap-2");
+    expect(within(metaRow).getByText("メンバーA")).toBeInTheDocument();
+    expect(within(metaRow).getByText("01/15(木) 19:30")).toBeInTheDocument();
+  });
+
+  it("keeps edit actions below the bubble in edit mode", () => {
+    const { container } = render(
+      <ToastProvider><ChatMessage
+        record={textRecord}
+        participantName="メンバーA"
+        conversationId="conv-1"
+        isEditMode
+        displayName=""
+      /></ToastProvider>,
+    );
+
+    const bubble = screen.getByText("テスト内容").closest("div");
+    const editActions = screen.getByTestId("message-edit-actions");
+
+    expect(bubble?.compareDocumentPosition(editActions)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(
+      within(editActions).getByRole("button", { name: "操作" }),
+    ).toBeInTheDocument();
+    expect(container.querySelector('[data-testid="message-edit-actions"]')).not
+      .toBeNull();
+  });
+
   it("switches to edit form when edit button is clicked", () => {
     render(
       <ToastProvider><ChatMessage

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -140,7 +140,17 @@ export const ChatMessage = memo(function ChatMessage({
           thumbnailUrl={participantThumbnailUrl}
         />
         <div className="min-w-0 flex-1">
-          <p className="text-xs font-medium text-gray-600">{participantName}</p>
+          <div
+            data-testid="message-meta-row"
+            className="flex items-baseline gap-2"
+          >
+            <p className="text-xs font-medium text-gray-600">
+              {participantName}
+            </p>
+            <span className="text-[10px] text-gray-500">
+              {formatMessageDateTimeJst(record.postedAt)}
+            </span>
+          </div>
           <div className="mt-1 rounded-lg border border-blue-200 bg-blue-50 p-3">
             <form action={formAction} className="space-y-2">
               <div>
@@ -206,7 +216,17 @@ export const ChatMessage = memo(function ChatMessage({
         thumbnailUrl={participantThumbnailUrl}
       />
       <div className="min-w-0 max-w-[85%] sm:max-w-[75%]">
-        <p className="text-xs font-medium text-gray-600">{participantName}</p>
+        <div
+          data-testid="message-meta-row"
+          className="flex items-baseline gap-2"
+        >
+          <p className="text-xs font-medium text-gray-600">
+            {participantName}
+          </p>
+          <span className="text-[10px] text-gray-500">
+            {formatMessageDateTimeJst(record.postedAt)}
+          </span>
+        </div>
         <div className="mt-0.5 rounded-lg rounded-tl-none bg-white px-3 py-2 shadow-sm">
           {record.title && (
             <p className="text-xs font-semibold text-gray-800">
@@ -220,11 +240,11 @@ export const ChatMessage = memo(function ChatMessage({
           )}
           {mediaUrl && <MediaContent record={record} mediaUrl={mediaUrl} />}
         </div>
-        <div className="mt-0.5 flex items-center gap-2">
-          <span className="text-[10px] text-gray-500">
-            {formatMessageDateTimeJst(record.postedAt)}
-          </span>
-          {isEditMode && (
+        {isEditMode && (
+          <div
+            data-testid="message-edit-actions"
+            className="mt-0.5 flex items-center gap-2"
+          >
             <>
               <div className="hidden gap-1 sm:group-hover:flex sm:group-focus-within:flex">
                 {record.recordType === "text" && (
@@ -265,8 +285,8 @@ export const ChatMessage = memo(function ChatMessage({
                 </svg>
               </button>
             </>
-          )}
-        </div>
+          </div>
+        )}
         {isEditMode && isActionMenuOpen && (
           <div
             role="menu"

--- a/src/components/ChatView.test.tsx
+++ b/src/components/ChatView.test.tsx
@@ -92,6 +92,12 @@ describe("ChatView", () => {
     expect(screen.getByText("二番目のメッセージ")).toBeInTheDocument();
   });
 
+  it("uses wider spacing between messages", () => {
+    render(<ToastProvider><ChatView conversation={conversation} mediaUrls={{}} displayName="" /></ToastProvider>);
+
+    expect(screen.getByTestId("message-list")).toHaveClass("space-y-5");
+  });
+
   it("renders participant name with messages", () => {
     render(<ToastProvider><ChatView conversation={conversation} mediaUrls={{}} displayName="" /></ToastProvider>);
 

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -361,29 +361,31 @@ export function ChatView({
             トークレコードがまだありません。
           </p>
         ) : (
-          dateGroups.map((group) => (
-            <div key={group.dateKey}>
-              <div className="space-y-3">
-                {group.records.map((record) => {
-                  const participant = participantMap.get(
-                    record.speakerParticipantId,
-                  );
-                  return (
-                    <ChatMessage
-                      key={record.id}
-                      record={record}
-                      participantName={participant?.name ?? "不明"}
-                      participantThumbnailUrl={participant?.thumbnailUrl}
-                      conversationId={conversation.id}
-                      mediaUrl={mediaUrls[record.id]}
-                      isEditMode={isEditMode}
-                      displayName={displayName}
-                    />
-                  );
-                })}
+          <div data-testid="message-list" className="space-y-5">
+            {dateGroups.map((group) => (
+              <div key={group.dateKey}>
+                <div className="space-y-5">
+                  {group.records.map((record) => {
+                    const participant = participantMap.get(
+                      record.speakerParticipantId,
+                    );
+                    return (
+                      <ChatMessage
+                        key={record.id}
+                        record={record}
+                        participantName={participant?.name ?? "不明"}
+                        participantThumbnailUrl={participant?.thumbnailUrl}
+                        conversationId={conversation.id}
+                        mediaUrl={mediaUrls[record.id]}
+                        isEditMode={isEditMode}
+                        displayName={displayName}
+                      />
+                    );
+                  })}
+                </div>
               </div>
-            </div>
-          ))
+            ))}
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
## 概要
- メッセージ日時を参加者名の横にインライン表示
- editMode 時の操作ボタンは吹き出し下に残すように調整
- メッセージ一覧の間隔を `space-y-5` に広げて視認性を改善

## 検証
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`

Closes #102