### PR TITLE
fix: モバイル UI のダークモード文字色と固定レイアウトを改善

### DIFF
--- a/src/app/(app)/conversations/[id]/loading.test.tsx
+++ b/src/app/(app)/conversations/[id]/loading.test.tsx
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import ConversationLoading from "./loading";
+
+describe("ConversationLoading", () => {
+  it("uses the fixed-height chat layout", () => {
+    const { container } = render(<ConversationLoading />);
+    const loadingShell = container.firstElementChild;
+
+    expect(loadingShell).toHaveClass("h-full");
+    expect(loadingShell).not.toHaveClass("min-h-[calc(100dvh-4rem)]");
+  });
+});

--- a/src/app/(app)/conversations/[id]/loading.tsx
+++ b/src/app/(app)/conversations/[id]/loading.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from "@/components/Skeleton";
 
 export default function ConversationLoading() {
   return (
-    <div className="-m-4 flex min-h-[calc(100dvh-4rem)] flex-col bg-gray-100 sm:-m-6 lg:h-[100dvh] lg:min-h-0">
+    <div className="-m-4 flex h-full flex-col bg-gray-100 sm:-m-6">
       {/* Header */}
       <div className="flex items-center gap-2 border-b border-gray-300 bg-white px-4 py-3">
         <Skeleton className="h-5 w-5" />

--- a/src/app/(app)/layout.test.tsx
+++ b/src/app/(app)/layout.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const createSupabaseServerClientMock = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: createSupabaseServerClientMock,
+}));
+
+vi.mock("@/app/login/actions", () => ({
+  logout: vi.fn(),
+}));
+
+describe("AppLayout", () => {
+  it("locks the app shell to the viewport and lets main scroll internally", async () => {
+    createSupabaseServerClientMock.mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { email: "test@example.com" } },
+        }),
+      },
+    });
+
+    const { default: AppLayout } = await import("./layout");
+    const { container } = render(
+      await AppLayout({
+        children: <div>content</div>,
+      }),
+    );
+
+    const appShell = container.firstElementChild;
+    expect(appShell).toHaveClass("h-dvh", "overflow-hidden");
+    expect(appShell).not.toHaveClass("min-h-screen");
+
+    const main = screen.getByText("content").closest("main");
+    expect(main).toHaveClass("min-h-0", "flex-1", "overflow-y-auto");
+  });
+});

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -12,9 +12,11 @@ export default async function AppLayout({
   } = await supabase.auth.getUser();
 
   return (
-    <div className="flex min-h-screen flex-col bg-white lg:h-screen lg:flex-row">
+    <div className="flex h-dvh flex-col overflow-hidden bg-white lg:flex-row">
       <Sidebar userEmail={user?.email ?? ""} />
-      <main className="flex-1 overflow-y-auto p-4 sm:p-6">{children}</main>
+      <main className="min-h-0 flex-1 overflow-y-auto p-4 sm:p-6">
+        {children}
+      </main>
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,13 +12,6 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 body {
   background: var(--background);
   color: var(--foreground);

--- a/src/app/globals.test.ts
+++ b/src/app/globals.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("globals.css", () => {
+  it("keeps the app in light mode regardless of OS color scheme", () => {
+    const css = readFileSync("src/app/globals.css", "utf8");
+
+    expect(css).toContain("--background: #ffffff");
+    expect(css).toContain("--foreground: #171717");
+    expect(css).not.toContain("prefers-color-scheme: dark");
+  });
+});

--- a/src/components/ChatView.test.tsx
+++ b/src/components/ChatView.test.tsx
@@ -85,6 +85,14 @@ describe("ChatView", () => {
     expect(screen.getByText("テスト会話")).toBeInTheDocument();
   });
 
+  it("fills the available app shell height on mobile", () => {
+    const { container } = render(<ToastProvider><ChatView conversation={conversation} mediaUrls={{}} displayName="" /></ToastProvider>);
+
+    const chatShell = container.firstElementChild;
+    expect(chatShell).toHaveClass("h-full");
+    expect(chatShell).not.toHaveClass("min-h-[calc(100dvh-4rem)]");
+  });
+
   it("renders record content", () => {
     render(<ToastProvider><ChatView conversation={conversation} mediaUrls={{}} displayName="" /></ToastProvider>);
 

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -169,7 +169,7 @@ export function ChatView({
   }, [targetRecordId, scrollToRecord]);
 
   return (
-    <div className="-m-4 flex min-h-[calc(100dvh-4rem)] flex-col bg-gray-100 sm:-m-6 lg:h-[100dvh] lg:min-h-0">
+    <div className="-m-4 flex h-full flex-col bg-gray-100 sm:-m-6">
       {/* Header */}
       <div className="flex items-center gap-2 border-b border-gray-300 bg-white px-3 py-3 sm:px-4">
         <Link

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -74,4 +74,13 @@ describe("Sidebar", () => {
     fireEvent.click(overlay);
     expect(screen.queryByRole("dialog", { name: "ナビゲーション" })).toBeNull();
   });
+
+  it("keeps the mobile header from shrinking in the fixed app shell", () => {
+    render(<Sidebar userEmail="test@example.com" />);
+
+    const [mobileTitleLink] = screen.getAllByRole("link", {
+      name: "トークアーカイブ",
+    });
+    expect(mobileTitleLink.closest("div")).toHaveClass("shrink-0");
+  });
 });

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -90,7 +90,7 @@ export function Sidebar({ userEmail }: SidebarProps) {
 
   return (
     <>
-      <div className="flex items-center justify-between border-b border-gray-200 bg-gray-50 px-4 py-3 lg:hidden">
+      <div className="flex shrink-0 items-center justify-between border-b border-gray-200 bg-gray-50 px-4 py-3 lg:hidden">
         <Link href="/" className="text-lg font-bold">
           トークアーカイブ
         </Link>


### PR DESCRIPTION
## 概要
- `globals.css` の dark mode ブロックを削除し、ライトモード専用の背景・文字色に固定
- AppLayout を `h-dvh overflow-hidden` に変更し、main に `min-h-0` を追加
- Sidebar のモバイルヘッダーを `shrink-0` にして固定高さレイアウトで潰れないように変更
- ChatView と loading skeleton を `h-full` ベースに変更し、Timeline の内部スクロールを有効化
- レイアウト崩れ防止のテストを追加

## 検証
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`

Closes #106