### PR TITLE
refactor: サムネイル管理UIを概要画面へ移動

### DIFF
--- a/src/app/(app)/conversations/[id]/overview/page.test.tsx
+++ b/src/app/(app)/conversations/[id]/overview/page.test.tsx
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ConversationWithRecords } from "@/usecases/conversationUseCases";
+import { ToastProvider } from "@/components/ToastProvider";
+
+const createSupabaseServerClientMock = vi.fn();
+const getConversationWithRecordsMock = vi.fn();
+const getParticipantThumbnailUrlsMock = vi.fn();
+const getConversationCoverUrlsMock = vi.fn();
+const redirectMock = vi.fn();
+const notFoundMock = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: createSupabaseServerClientMock,
+}));
+
+vi.mock("@/usecases/conversationUseCases", () => ({
+  getConversationWithRecords: getConversationWithRecordsMock,
+  getParticipantThumbnailUrls: getParticipantThumbnailUrlsMock,
+  getConversationCoverUrls: getConversationCoverUrlsMock,
+}));
+
+vi.mock("@/app/(app)/conversations/[id]/actions", () => ({
+  updateConversationAction: vi.fn(),
+  deleteConversationAction: vi.fn(),
+  updateParticipantThumbnailAction: vi.fn(),
+  updateConversationCoverImageAction: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: redirectMock,
+  notFound: notFoundMock,
+}));
+
+const conversation: ConversationWithRecords = {
+  id: "conv-1",
+  userId: "user-1",
+  sourceId: null,
+  idolGroup: "nogizaka",
+  coverImagePath: "user-1/participants/part-1/photo.jpg",
+  title: "テスト会話",
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+  activePeriods: [
+    {
+      id: "period-1",
+      conversationId: "conv-1",
+      startDate: "2026-01-01",
+      endDate: null,
+      createdAt: "2026-01-01T00:00:00Z",
+    },
+  ],
+  participants: [
+    {
+      id: "part-1",
+      conversationId: "conv-1",
+      name: "メンバーA",
+      sortOrder: 0,
+      thumbnailPath: "user-1/participants/part-1/photo.jpg",
+      createdAt: "2026-01-01T00:00:00Z",
+    },
+  ],
+  activeDays: 1,
+  records: [],
+};
+
+function mockSupabaseUser(user: { id: string } | null) {
+  createSupabaseServerClientMock.mockResolvedValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user },
+      }),
+    },
+  });
+}
+
+describe("ConversationOverviewPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getConversationWithRecordsMock.mockResolvedValue(conversation);
+    getParticipantThumbnailUrlsMock.mockResolvedValue(
+      new Map([["part-1", "https://example.com/member-a.jpg"]]),
+    );
+    getConversationCoverUrlsMock.mockResolvedValue(
+      new Map([["conv-1", "https://example.com/cover.jpg"]]),
+    );
+  });
+
+  it("redirects to /login when user is not available", async () => {
+    mockSupabaseUser(null);
+    redirectMock.mockImplementation(() => {
+      throw new Error("NEXT_REDIRECT");
+    });
+
+    const { default: ConversationOverviewPage } = await import("./page");
+
+    await expect(
+      ConversationOverviewPage({
+        params: Promise.resolve({ id: "conv-1" }),
+      }),
+    ).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(redirectMock).toHaveBeenCalledWith("/login");
+    expect(getConversationWithRecordsMock).not.toHaveBeenCalled();
+  });
+
+  it("renders thumbnail manager with signed thumbnail URLs", async () => {
+    mockSupabaseUser({ id: "user-1" });
+
+    const { default: ConversationOverviewPage } = await import("./page");
+    render(
+      <ToastProvider>
+        {await ConversationOverviewPage({
+          params: Promise.resolve({ id: "conv-1" }),
+        })}
+      </ToastProvider>,
+    );
+
+    expect(getParticipantThumbnailUrlsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      conversation.participants,
+    );
+    expect(getConversationCoverUrlsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      [conversation],
+    );
+    expect(screen.getByText("サムネイル")).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "メンバーAのサムネイル" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("メンバーAのサムネイル画像"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/(app)/conversations/[id]/overview/page.tsx
+++ b/src/app/(app)/conversations/[id]/overview/page.tsx
@@ -1,6 +1,10 @@
 import { notFound, redirect } from "next/navigation";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
-import { getConversationWithRecords } from "@/usecases/conversationUseCases";
+import {
+  getConversationCoverUrls,
+  getConversationWithRecords,
+  getParticipantThumbnailUrls,
+} from "@/usecases/conversationUseCases";
 import { ConversationActions } from "@/components/ConversationActions";
 import { ConversationSubpageLayout } from "@/components/ConversationSubpageLayout";
 
@@ -28,12 +32,29 @@ export default async function ConversationOverviewPage({
     notFound();
   }
 
+  const [participantThumbnailUrlMap, coverImageUrlMap] = await Promise.all([
+    getParticipantThumbnailUrls(supabase, conversation.participants),
+    getConversationCoverUrls(supabase, [conversation]),
+  ]);
+
+  const participantThumbnailUrls: { [participantId: string]: string } = {};
+  for (const participant of conversation.participants) {
+    const thumbnailUrl = participantThumbnailUrlMap.get(participant.id);
+    if (thumbnailUrl) {
+      participantThumbnailUrls[participant.id] = thumbnailUrl;
+    }
+  }
+
   return (
     <ConversationSubpageLayout
       conversationId={conversation.id}
       title="概要"
     >
-      <ConversationActions conversation={conversation} />
+      <ConversationActions
+        conversation={conversation}
+        participantThumbnailUrls={participantThumbnailUrls}
+        coverImageUrl={coverImageUrlMap.get(conversation.id)}
+      />
     </ConversationSubpageLayout>
   );
 }

--- a/src/app/(app)/conversations/[id]/page.tsx
+++ b/src/app/(app)/conversations/[id]/page.tsx
@@ -3,7 +3,6 @@ import { notFound, redirect } from "next/navigation";
 import { cache } from "react";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import {
-  getConversationCoverUrls,
   getConversationWithRecords,
   getParticipantThumbnailUrls,
 } from "@/usecases/conversationUseCases";
@@ -53,10 +52,9 @@ export default async function ConversationDetailPage({
     notFound();
   }
 
-  const [mediaUrlMap, participantThumbnailUrlMap, coverImageUrlMap, displayName] = await Promise.all([
+  const [mediaUrlMap, participantThumbnailUrlMap, displayName] = await Promise.all([
     getMediaUrlsForRecords(supabase, conversation.records),
     getParticipantThumbnailUrls(supabase, conversation.participants),
-    getConversationCoverUrls(supabase, [conversation]),
     getDisplayName(supabase, user.id),
   ]);
 
@@ -80,7 +78,6 @@ export default async function ConversationDetailPage({
       conversation={conversation}
       mediaUrls={mediaUrls}
       participantThumbnailUrls={participantThumbnailUrls}
-      coverImageUrl={coverImageUrlMap.get(conversation.id)}
       displayName={displayName}
     />
   );

--- a/src/components/ChatView.test.tsx
+++ b/src/components/ChatView.test.tsx
@@ -247,8 +247,10 @@ describe("ChatView", () => {
     expect(
       screen.getByText("編集モード中です。各レコードの操作メニューから編集・削除できます。"),
     ).toBeInTheDocument();
-    expect(screen.getByText("サムネイル")).toBeInTheDocument();
-    expect(screen.getByLabelText("メンバーAのサムネイル画像")).toBeInTheDocument();
+    expect(screen.queryByText("サムネイル")).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("メンバーAのサムネイル画像"),
+    ).not.toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: "操作" }).length).toBeGreaterThan(0);
   });
 

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -11,7 +11,6 @@ import type { MediaUrl } from "@/usecases/recordUseCases";
 import { replaceMyNamePlaceholder } from "@/usecases/contentTransform";
 import { ChatMessage } from "@/components/ChatMessage";
 import { ChatComposer } from "@/components/ChatComposer";
-import { ConversationThumbnailManager } from "@/components/ConversationThumbnailManager";
 const DateSearchModal = dynamic(
   () =>
     import("@/components/DateSearchModal").then((m) => m.DateSearchModal),
@@ -22,7 +21,6 @@ type ChatViewProps = {
   conversation: ConversationWithRecords;
   mediaUrls: { [recordId: string]: MediaUrl };
   participantThumbnailUrls?: { [participantId: string]: string };
-  coverImageUrl?: string;
   displayName: string;
 };
 
@@ -93,7 +91,6 @@ export function ChatView({
   conversation,
   mediaUrls,
   participantThumbnailUrls = {},
-  coverImageUrl,
   displayName,
 }: ChatViewProps) {
   const participantMap = useMemo(
@@ -296,16 +293,6 @@ export function ChatView({
             終了
           </button>
         </div>
-      )}
-
-      {isEditMode && (
-        <ConversationThumbnailManager
-          conversationId={conversation.id}
-          participants={conversation.participants}
-          participantThumbnailUrls={participantThumbnailUrls}
-          coverImagePath={conversation.coverImagePath}
-          coverImageUrl={coverImageUrl}
-        />
       )}
 
       {/* Search Bar */}

--- a/src/components/ConversationActions.test.tsx
+++ b/src/components/ConversationActions.test.tsx
@@ -7,6 +7,8 @@ import type { ConversationWithMetadata } from "@/usecases/conversationUseCases";
 vi.mock("@/app/(app)/conversations/[id]/actions", () => ({
   updateConversationAction: vi.fn(),
   deleteConversationAction: vi.fn(),
+  updateParticipantThumbnailAction: vi.fn(),
+  updateConversationCoverImageAction: vi.fn(),
 }));
 
 const conversation: ConversationWithMetadata = {
@@ -47,6 +49,28 @@ describe("ConversationActions", () => {
     expect(screen.getByText("テスト会話")).toBeInTheDocument();
     expect(screen.getByText("編集")).toBeInTheDocument();
     expect(screen.getByText("会話を削除")).toBeInTheDocument();
+  });
+
+  it("renders thumbnail manager on overview", () => {
+    render(
+      <ToastProvider>
+        <ConversationActions
+          conversation={conversation}
+          participantThumbnailUrls={{
+            "part-1": "https://example.com/member-a.jpg",
+          }}
+          coverImageUrl="https://example.com/cover.jpg"
+        />
+      </ToastProvider>,
+    );
+
+    expect(screen.getByText("サムネイル")).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "メンバーAのサムネイル" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("メンバーAのサムネイル画像"),
+    ).toBeInTheDocument();
   });
 
   it("switches to edit form when edit button is clicked", () => {

--- a/src/components/ConversationActions.tsx
+++ b/src/components/ConversationActions.tsx
@@ -4,16 +4,21 @@ import { useState } from "react";
 import { ConversationHeader } from "@/components/ConversationHeader";
 import { EditConversationForm } from "@/components/EditConversationForm";
 import { DeleteConversationButton } from "@/components/DeleteConversationButton";
+import { ConversationThumbnailManager } from "@/components/ConversationThumbnailManager";
 import type { ConversationWithMetadata } from "@/usecases/conversationUseCases";
 
 type ConversationActionsProps = {
   conversation: ConversationWithMetadata;
   defaultEditing?: boolean;
+  participantThumbnailUrls?: { [participantId: string]: string };
+  coverImageUrl?: string;
 };
 
 export function ConversationActions({
   conversation,
   defaultEditing = false,
+  participantThumbnailUrls = {},
+  coverImageUrl,
 }: ConversationActionsProps) {
   const [isEditing, setIsEditing] = useState(defaultEditing);
 
@@ -29,6 +34,15 @@ export function ConversationActions({
   return (
     <div>
       <ConversationHeader conversation={conversation} />
+      <div className="mt-5">
+        <ConversationThumbnailManager
+          conversationId={conversation.id}
+          participants={conversation.participants}
+          participantThumbnailUrls={participantThumbnailUrls}
+          coverImagePath={conversation.coverImagePath}
+          coverImageUrl={coverImageUrl}
+        />
+      </div>
       <div className="mt-3 flex gap-3">
         <button
           type="button"


### PR DESCRIPTION
## 概要
- `ConversationThumbnailManager` をトーク画面の編集モードから削除
- 概要画面の `ConversationActions` 内にサムネイル管理セクションを追加
- Overview page で参加者サムネイル / 会話カバーの署名 URL を取得して渡すように変更
- トーク詳細ページでは会話カバー URL の取得をやめ、メッセージアバター用の参加者サムネイル URL のみに整理
- 移動先/移動元の回帰防止テストを追加

## 検証
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`

Closes #107