### PR TITLE
chore: Supabase CLI をバージョン固定し生成型の後処理をマップ駆動で自動化

### DIFF
--- a/.claude/skills/migration/SKILL.md
+++ b/.claude/skills/migration/SKILL.md
@@ -14,7 +14,9 @@ argument-hint: "<DB変更の内容>"
 
 - ファイル名: `YYYYMMDDHHMMSS_snake_case_summary.sql`（UTC タイムスタンプ。既存 migration の命名に合わせる）
   - `npx supabase migration new <summary>` で生成するか、現在時刻から手動で命名する
-    （Supabase CLI は依存に含まれないため、既存スクリプトと同様に `npx` 経由で実行する — `scripts/generate-db-types.mjs` 参照）
+    （Supabase CLI は devDependencies にバージョン固定で追加済みのため、`npx supabase ...` は
+    常にその固定版を実行する — `scripts/generate-db-types.mjs` 参照。バージョンを上げる場合は
+    `pnpm add -D -E supabase@<version>` で明示的に固定し直す）
   - 既存ファイルより新しいタイムスタンプになっていることを確認する
 - データ投入は migration ではなく `supabase/seed.sql` に置く
 - ファイル冒頭に目的をコメントで書く（既存 migration のスタイルに合わせる）
@@ -44,6 +46,10 @@ argument-hint: "<DB変更の内容>"
   （ローカル Supabase が起動していなければ `npx supabase start`）
 - スキーマを変えたら Database 型を再生成する: `pnpm db:gen-types`
   （`src/types/database.ts` が更新される）
+  - RPC の引数を追加・変更した場合、`scripts/generate-db-types.mjs` の
+    `NULLABLE_RPC_ARGUMENTS`（既知の CLI リグレッション対応の後処理マップ。
+    詳細は `docs/development.md` の「DB型生成」節）を更新する必要がないか確認する。
+    対象外の引数が見つからない場合はスクリプトがエラーで停止するため、その場合は必ず対応する
 - `pnpm typecheck && pnpm lint && pnpm test` と、関連画面の手動確認を行う
 - **本番へ反映**: `npx supabase db push` は本番 DB への書き込みのため **ユーザーが実行する**
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -51,3 +51,35 @@ PRは小さくする。
 - Component test
 
 Vitest + Testing Library
+
+---
+
+## DB型生成（`src/types/database.ts`）
+
+`pnpm db:gen-types`（`scripts/generate-db-types.mjs`）でローカル Supabase のスキーマから
+`src/types/database.ts` を再生成する。マイグレーションを追加・変更したら必ず実行する
+（`.claude/skills/migration/SKILL.md` 参照）。
+
+### Supabase CLI はバージョン固定（devDependency）
+
+`supabase` を `package.json` の devDependencies にキャレットなしで固定しており、
+`npx supabase ...` は常にこの固定版を解決する（`npx supabase --version` で確認できる）。
+バージョンを上げる際は `pnpm add -D -E supabase@<version>` で明示的に固定し直す。
+
+### RPC引数のnullable後処理（既知のCLIリグレッション対応）
+
+Issue #123 で確認した通り、現行の `supabase gen types typescript` は Postgres 側で NOT NULL
+制約を持たない RPC 引数（そもそも Postgres の関数引数に NOT NULL という概念はない）を
+一律で non-nullable（`string`）として生成する。これは 2026-07 時点で入手できたどのバージョン
+（PostgreSQL 17 ローカルスタックと互換性のある範囲）でも再現し、CLI バージョン固定だけでは
+解決できなかった。
+
+そのため `scripts/generate-db-types.mjs` は生成直後の出力に対して、決定的な後処理
+（関数名・引数名を明示したマップ `NULLABLE_RPC_ARGUMENTS`）を適用し、実際に `null` を渡している
+呼び出し元（`src/repositories/*.ts`）や対象カラムのnullable制約に合わせて `| null` を復元する。
+マップにはそれぞれの根拠をコメントで記載している。対象の関数・引数がスキーマ変更で見つからなく
+なった場合はスクリプトがエラーで停止するため、マイグレーションでRPCの引数を変更したときは
+このマップも合わせて更新すること。
+
+`pnpm db:gen-types` を2回連続で実行しても差分が出ないこと（冪等であること）を、
+このスクリプトを変更した際は必ず確認する。

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "jsdom": "^28.1.0",
+    "supabase": "2.109.1",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^4.0.18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,7 +53,10 @@ importers:
         version: 16.1.6(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       jsdom:
         specifier: ^28.1.0
-        version: 28.1.0
+        version: 28.1.0(@noble/hashes@1.8.0)
+      supabase:
+        specifier: 2.109.1
+        version: 2.109.1
       tailwindcss:
         specifier: ^4
         version: 4.2.1
@@ -62,7 +65,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@20.19.37)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)
+        version: 4.0.18(@types/node@20.19.37)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)
 
 packages:
 
@@ -191,6 +194,12 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@ecies/ciphers@0.2.6':
+    resolution: {integrity: sha512-patgsRPKGkhhoBjETV4XxD0En4ui5fbX0hzayqI3M8tvNMGUoUvmyYAIWwlxBc1KX5cturfqByYdj5bYGRpN9g==}
+    engines: {bun: '>=1', deno: '>=2.7.10', node: '>=16'}
+    peerDependencies:
+      '@noble/ciphers': ^1.0.0
 
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
@@ -630,6 +639,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.7':
+    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -780,6 +801,46 @@ packages:
   '@supabase/auth-js@2.99.0':
     resolution: {integrity: sha512-tHiIST/OEoLmWBE+3X69xRY5srJM/lL86KltmMlIfDo9ePJLo14vQQV9T4NF+P+MoGhCwQL1GTmk51zuAFMXKw==}
     engines: {node: '>=20.0.0'}
+
+  '@supabase/cli-darwin-arm64@2.109.1':
+    resolution: {integrity: sha512-tkn8tfunyqIL7RE+7DVjg6Ql2cJLPkGgh9cPafp2LbXI0qDgds0TaS+UOTHQEjci8JQXXe2wS00+122ko2QI8A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@supabase/cli-darwin-x64@2.109.1':
+    resolution: {integrity: sha512-0Q5ZAoWhOyIv4ZzQOU8QbjjdB2JmznnDNyJ3VrIeuLMWoifVfUWaLZhHBNYzr4xXoxBpKrggomuAT8BaEhY3lg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@supabase/cli-linux-arm64-musl@2.109.1':
+    resolution: {integrity: sha512-cXNOsSU7MS+jmslGQATTD4DfWBEIHiFi7LaBWyBxHmR7tzIiZXimUXgN26ZiQjfAxU+RZq52C3k0qhi7vmqXQw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@supabase/cli-linux-arm64@2.109.1':
+    resolution: {integrity: sha512-MS1djJjq5laD99+jYJUoARfSZhzRX9aXmo5piZ1yl2JXb9IXTuhiTD5olkFKQcgNckRcAZqMf4fucQGTYC767A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@supabase/cli-linux-x64-musl@2.109.1':
+    resolution: {integrity: sha512-zeD9MrZpEKJrjkSPcYp4nZeGJ9FQt0i/kiRij4ZprPP6R5l+SLi6Pk20ln+Vj/GZuWTVxX7IHJ11pgViaReAWw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@supabase/cli-linux-x64@2.109.1':
+    resolution: {integrity: sha512-svFmamF/vIq4/oinwY50jDi869itC9/GWrPaGtsHFkK4NUBcQtl1T37WWIivGsXwbBKNC4FjZD3dGqjL7bfW1g==}
+    cpu: [x64]
+    os: [linux]
+
+  '@supabase/cli-windows-arm64@2.109.1':
+    resolution: {integrity: sha512-NeKzgWAOpglnLwMTggTp5t44fbkfxACLkQNlCRx0q332HMM3WqsKQUsHv1MHc6ZbEc5bcMwaYjqPNI/aOWnP5g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@supabase/cli-windows-x64@2.109.1':
+    resolution: {integrity: sha512-L9/pDLM+4IR8646aT69ZDVcnJeg1lZZsB26ZgI775S3f8jOHP41+1UH9Oq1g9CvKiAQviuaLgtwkuvi0I/cc/A==}
+    cpu: [x64]
+    os: [win32]
 
   '@supabase/functions-js@2.99.0':
     resolution: {integrity: sha512-zA9oad6EqGwMLLu2LfP1bXbqKcJGiotAdbdTfZG7YS7619YZQAEgejj9mp+E5vglKE1yMWbKK+S1J3PbuUtgLg==}
@@ -1409,6 +1470,10 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eciesjs@0.5.0:
+    resolution: {integrity: sha512-s0J9SEVYAEPg7J63GFMApLYzPH9VNIQIyC6s15JpnqVc0TqcKWdbgFlnAweEBRyMmko2dcs2sfC83Hj4J43tuA==}
+    engines: {bun: '>=1', deno: '>=2.7.10', node: '>=16'}
+
   electron-to-chromium@1.5.307:
     resolution: {integrity: sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==}
 
@@ -1903,6 +1968,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2438,6 +2506,10 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  supabase@2.109.1:
+    resolution: {integrity: sha512-N2yP2MHTxOxXBWhfn3poudpJn4pkPosAUo7J/46FTou/l7wOwFi9tox8NSN6HljWkfM0zhwPRimNNGC9XBMoxQ==}
+    hasBin: true
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2866,6 +2938,10 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
+  '@ecies/ciphers@0.2.6(@noble/ciphers@1.3.0)':
+    dependencies:
+      '@noble/ciphers': 1.3.0
+
   '@emnapi/core@1.8.1':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
@@ -3006,7 +3082,9 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@exodus/bytes@1.15.0': {}
+  '@exodus/bytes@1.15.0(@noble/hashes@1.8.0)':
+    optionalDependencies:
+      '@noble/hashes': 1.8.0
 
   '@humanfs/core@0.19.1': {}
 
@@ -3172,6 +3250,14 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.1.6':
     optional: true
 
+  '@noble/ciphers@1.3.0': {}
+
+  '@noble/curves@1.9.7':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/hashes@1.8.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3268,6 +3354,30 @@ snapshots:
   '@supabase/auth-js@2.99.0':
     dependencies:
       tslib: 2.8.1
+
+  '@supabase/cli-darwin-arm64@2.109.1':
+    optional: true
+
+  '@supabase/cli-darwin-x64@2.109.1':
+    optional: true
+
+  '@supabase/cli-linux-arm64-musl@2.109.1':
+    optional: true
+
+  '@supabase/cli-linux-arm64@2.109.1':
+    optional: true
+
+  '@supabase/cli-linux-x64-musl@2.109.1':
+    optional: true
+
+  '@supabase/cli-linux-x64@2.109.1':
+    optional: true
+
+  '@supabase/cli-windows-arm64@2.109.1':
+    optional: true
+
+  '@supabase/cli-windows-x64@2.109.1':
+    optional: true
 
   '@supabase/functions-js@2.99.0':
     dependencies:
@@ -3851,10 +3961,10 @@ snapshots:
 
   damerau-levenshtein@1.0.8: {}
 
-  data-urls@7.0.0:
+  data-urls@7.0.0(@noble/hashes@1.8.0):
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -3917,6 +4027,13 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  eciesjs@0.5.0:
+    dependencies:
+      '@ecies/ciphers': 0.2.6(@noble/ciphers@1.3.0)
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
 
   electron-to-chromium@1.5.307: {}
 
@@ -4419,9 +4536,9 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  html-encoding-sniffer@6.0.0:
+  html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -4589,22 +4706,24 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@6.2.3: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@28.1.0:
+  jsdom@28.1.0(@noble/hashes@1.8.0):
     dependencies:
       '@acemir/cssom': 0.9.31
       '@asamuzakjp/dom-selector': 6.8.1
       '@bramus/specificity': 2.4.2
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
       cssstyle: 6.2.0
-      data-urls: 7.0.0
+      data-urls: 7.0.0(@noble/hashes@1.8.0)
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
@@ -4616,7 +4735,7 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -5205,6 +5324,20 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
 
+  supabase@2.109.1:
+    dependencies:
+      eciesjs: 0.5.0
+      jose: 6.2.3
+    optionalDependencies:
+      '@supabase/cli-darwin-arm64': 2.109.1
+      '@supabase/cli-darwin-x64': 2.109.1
+      '@supabase/cli-linux-arm64': 2.109.1
+      '@supabase/cli-linux-arm64-musl': 2.109.1
+      '@supabase/cli-linux-x64': 2.109.1
+      '@supabase/cli-linux-x64-musl': 2.109.1
+      '@supabase/cli-windows-arm64': 2.109.1
+      '@supabase/cli-windows-x64': 2.109.1
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -5368,7 +5501,7 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.31.1
 
-  vitest@4.0.18(@types/node@20.19.37)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1):
+  vitest@4.0.18(@types/node@20.19.37)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.31.1):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.31.1))
@@ -5392,7 +5525,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.37
-      jsdom: 28.1.0
+      jsdom: 28.1.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -5414,9 +5547,9 @@ snapshots:
 
   whatwg-mimetype@5.0.0: {}
 
-  whatwg-url@16.0.1:
+  whatwg-url@16.0.1(@noble/hashes@1.8.0):
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:

--- a/scripts/generate-db-types.mjs
+++ b/scripts/generate-db-types.mjs
@@ -3,55 +3,15 @@ import { dirname, join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import {
+  NULLABLE_RPC_ARGUMENTS,
+  markArgumentsNullable,
+} from "./nullable-rpc-arguments.mjs";
 
 const currentFilePath = fileURLToPath(import.meta.url);
 const repoRootPath = dirname(dirname(currentFilePath));
 const targetPath = join(repoRootPath, "src/types/database.ts");
 const temporaryPath = `${targetPath}.${randomUUID()}.tmp`;
-
-/**
- * Known regression (see Issue #123): every "supabase" CLI release we could
- * install and run against this project's local Postgres (2.40.0 through the
- * pinned devDependency version; anything older refuses to talk to Postgres
- * 17 at all) generates every plain RPC argument as non-nullable, regardless
- * of the target column's actual nullability. Postgres itself has no NOT
- * NULL concept for a plain function IN parameter, so `gen types` can only
- * infer nullability heuristically — and the current generator's heuristic
- * always says "non-null".
- *
- * The entries below restore `| null` for arguments that this app actually
- * calls with `null` (see the call sites and the schema each maps to). Keep
- * this map in sync with the RPC signatures in `supabase/migrations/`; the
- * post-processing step below fails loudly if a mapped argument disappears
- * or changes shape, and it is a no-op for any argument the CLI already
- * generates as nullable (e.g. once this upstream regression is fixed).
- */
-const NULLABLE_RPC_ARGUMENTS = {
-  // records.title has no NOT NULL constraint, and both repositories call
-  // these RPCs with `params.title ?? null` / `params.title: string | null`.
-  // records.content has no NOT NULL constraint either, but
-  // `records_text_content_check` requires it to be non-null whenever
-  // record_type = 'text' — append_text_record always inserts 'text', so
-  // p_content there is correctly non-nullable and is intentionally not
-  // listed below.
-  append_media_record: ["p_title", "p_content"],
-  append_text_record: ["p_title"],
-  // conversations.source_id and conversations.cover_image_path are
-  // nullable columns (optional FK / optional cover image); both repository
-  // call sites pass `params.sourceId ?? null` / `params.coverImagePath ?? null`.
-  create_conversation_with_metadata: ["p_source_id", "p_cover_image_path"],
-  // update_conversation_with_metadata is a "diff update" RPC: each p_has_*
-  // flag says whether the corresponding value should be applied at all, so
-  // the value itself is passed as `?? null` from the repository whenever
-  // the field is not being changed (see
-  // supabase/migrations/20260311083000_add_conversation_participants.sql).
-  update_conversation_with_metadata: [
-    "p_title",
-    "p_idol_group",
-    "p_source_id",
-    "p_cover_image_path",
-  ],
-};
 
 const result = spawnSync(
   "npx",
@@ -73,62 +33,6 @@ if (result.status !== 0) {
 if (!result.stdout || result.stdout.trim().length === 0) {
   process.stderr.write("Supabase type generation returned empty output.\n");
   process.exit(1);
-}
-
-/**
- * Rewrites `argName: SomeType` to `argName: SomeType | null` inside a single
- * RPC function's `Args: { ... }` block, without touching same-named
- * arguments in other functions (e.g. `p_title` is non-nullable in
- * `create_conversation_with_metadata` but nullable in `append_text_record`).
- * Throws if the function or the argument can't be found, so schema drift
- * that invalidates this map is caught immediately instead of silently
- * producing an incorrect committed type.
- */
-function markArgumentsNullable(source, functionName, argumentNames) {
-  const blockPattern = new RegExp(
-    `(      ${functionName}: \\{\\n        Args: \\{\\n)([\\s\\S]*?)(\\n        \\}\\n)`,
-  );
-  const blockMatch = source.match(blockPattern);
-  if (!blockMatch) {
-    throw new Error(
-      `db:gen-types: could not find an "Args: { ... }" block for RPC function "${functionName}". ` +
-        "It may have been renamed or removed — update NULLABLE_RPC_ARGUMENTS in scripts/generate-db-types.mjs.",
-    );
-  }
-
-  let argsBody = blockMatch[2];
-  for (const argumentName of argumentNames) {
-    const argumentPattern = new RegExp(
-      `(          ${argumentName}: )([^\\n]+)`,
-    );
-    const argumentMatch = argsBody.match(argumentPattern);
-    if (!argumentMatch) {
-      throw new Error(
-        `db:gen-types: could not find argument "${argumentName}" on RPC function "${functionName}". ` +
-          "It may have been renamed or removed — update NULLABLE_RPC_ARGUMENTS in scripts/generate-db-types.mjs.",
-      );
-    }
-
-    const currentType = argumentMatch[2];
-    if (currentType.includes("| null")) {
-      // Already nullable (e.g. the upstream CLI regression has been fixed
-      // for this argument) — nothing to patch.
-      continue;
-    }
-
-    argsBody = argsBody.replace(
-      argumentPattern,
-      `$1${currentType} | null`,
-    );
-  }
-
-  return (
-    source.slice(0, blockMatch.index) +
-    blockMatch[1] +
-    argsBody +
-    blockMatch[3] +
-    source.slice(blockMatch.index + blockMatch[0].length)
-  );
 }
 
 let patchedOutput = result.stdout;

--- a/scripts/generate-db-types.mjs
+++ b/scripts/generate-db-types.mjs
@@ -9,6 +9,50 @@ const repoRootPath = dirname(dirname(currentFilePath));
 const targetPath = join(repoRootPath, "src/types/database.ts");
 const temporaryPath = `${targetPath}.${randomUUID()}.tmp`;
 
+/**
+ * Known regression (see Issue #123): every "supabase" CLI release we could
+ * install and run against this project's local Postgres (2.40.0 through the
+ * pinned devDependency version; anything older refuses to talk to Postgres
+ * 17 at all) generates every plain RPC argument as non-nullable, regardless
+ * of the target column's actual nullability. Postgres itself has no NOT
+ * NULL concept for a plain function IN parameter, so `gen types` can only
+ * infer nullability heuristically — and the current generator's heuristic
+ * always says "non-null".
+ *
+ * The entries below restore `| null` for arguments that this app actually
+ * calls with `null` (see the call sites and the schema each maps to). Keep
+ * this map in sync with the RPC signatures in `supabase/migrations/`; the
+ * post-processing step below fails loudly if a mapped argument disappears
+ * or changes shape, and it is a no-op for any argument the CLI already
+ * generates as nullable (e.g. once this upstream regression is fixed).
+ */
+const NULLABLE_RPC_ARGUMENTS = {
+  // records.title has no NOT NULL constraint, and both repositories call
+  // these RPCs with `params.title ?? null` / `params.title: string | null`.
+  // records.content has no NOT NULL constraint either, but
+  // `records_text_content_check` requires it to be non-null whenever
+  // record_type = 'text' — append_text_record always inserts 'text', so
+  // p_content there is correctly non-nullable and is intentionally not
+  // listed below.
+  append_media_record: ["p_title", "p_content"],
+  append_text_record: ["p_title"],
+  // conversations.source_id and conversations.cover_image_path are
+  // nullable columns (optional FK / optional cover image); both repository
+  // call sites pass `params.sourceId ?? null` / `params.coverImagePath ?? null`.
+  create_conversation_with_metadata: ["p_source_id", "p_cover_image_path"],
+  // update_conversation_with_metadata is a "diff update" RPC: each p_has_*
+  // flag says whether the corresponding value should be applied at all, so
+  // the value itself is passed as `?? null` from the repository whenever
+  // the field is not being changed (see
+  // supabase/migrations/20260311083000_add_conversation_participants.sql).
+  update_conversation_with_metadata: [
+    "p_title",
+    "p_idol_group",
+    "p_source_id",
+    "p_cover_image_path",
+  ],
+};
+
 const result = spawnSync(
   "npx",
   ["supabase", "gen", "types", "typescript", "--local"],
@@ -31,8 +75,80 @@ if (!result.stdout || result.stdout.trim().length === 0) {
   process.exit(1);
 }
 
+/**
+ * Rewrites `argName: SomeType` to `argName: SomeType | null` inside a single
+ * RPC function's `Args: { ... }` block, without touching same-named
+ * arguments in other functions (e.g. `p_title` is non-nullable in
+ * `create_conversation_with_metadata` but nullable in `append_text_record`).
+ * Throws if the function or the argument can't be found, so schema drift
+ * that invalidates this map is caught immediately instead of silently
+ * producing an incorrect committed type.
+ */
+function markArgumentsNullable(source, functionName, argumentNames) {
+  const blockPattern = new RegExp(
+    `(      ${functionName}: \\{\\n        Args: \\{\\n)([\\s\\S]*?)(\\n        \\}\\n)`,
+  );
+  const blockMatch = source.match(blockPattern);
+  if (!blockMatch) {
+    throw new Error(
+      `db:gen-types: could not find an "Args: { ... }" block for RPC function "${functionName}". ` +
+        "It may have been renamed or removed — update NULLABLE_RPC_ARGUMENTS in scripts/generate-db-types.mjs.",
+    );
+  }
+
+  let argsBody = blockMatch[2];
+  for (const argumentName of argumentNames) {
+    const argumentPattern = new RegExp(
+      `(          ${argumentName}: )([^\\n]+)`,
+    );
+    const argumentMatch = argsBody.match(argumentPattern);
+    if (!argumentMatch) {
+      throw new Error(
+        `db:gen-types: could not find argument "${argumentName}" on RPC function "${functionName}". ` +
+          "It may have been renamed or removed — update NULLABLE_RPC_ARGUMENTS in scripts/generate-db-types.mjs.",
+      );
+    }
+
+    const currentType = argumentMatch[2];
+    if (currentType.includes("| null")) {
+      // Already nullable (e.g. the upstream CLI regression has been fixed
+      // for this argument) — nothing to patch.
+      continue;
+    }
+
+    argsBody = argsBody.replace(
+      argumentPattern,
+      `$1${currentType} | null`,
+    );
+  }
+
+  return (
+    source.slice(0, blockMatch.index) +
+    blockMatch[1] +
+    argsBody +
+    blockMatch[3] +
+    source.slice(blockMatch.index + blockMatch[0].length)
+  );
+}
+
+let patchedOutput = result.stdout;
+for (const [functionName, argumentNames] of Object.entries(
+  NULLABLE_RPC_ARGUMENTS,
+)) {
+  patchedOutput = markArgumentsNullable(
+    patchedOutput,
+    functionName,
+    argumentNames,
+  );
+}
+
+// The CLI emits a trailing blank line; normalize to a single trailing
+// newline so re-running this script is idempotent against the committed
+// file (and matches this repo's usual file-ending convention).
+patchedOutput = patchedOutput.replace(/\n+$/, "\n");
+
 try {
-  await writeFile(temporaryPath, result.stdout, "utf8");
+  await writeFile(temporaryPath, patchedOutput, "utf8");
   await rename(temporaryPath, targetPath);
 } catch (error) {
   await rm(temporaryPath, { force: true });

--- a/scripts/nullable-rpc-arguments.mjs
+++ b/scripts/nullable-rpc-arguments.mjs
@@ -1,0 +1,99 @@
+/**
+ * Known regression (see Issue #123): every "supabase" CLI release we could
+ * install and run against this project's local Postgres (2.40.0 through the
+ * pinned devDependency version; anything older refuses to talk to Postgres
+ * 17 at all) generates every plain RPC argument as non-nullable, regardless
+ * of the target column's actual nullability. Postgres itself has no NOT
+ * NULL concept for a plain function IN parameter, so `gen types` can only
+ * infer nullability heuristically — and the current generator's heuristic
+ * always says "non-null".
+ *
+ * The entries below restore `| null` for arguments that this app actually
+ * calls with `null` (see the call sites and the schema each maps to). Keep
+ * this map in sync with the RPC signatures in `supabase/migrations/`; the
+ * post-processing step below fails loudly if a mapped argument disappears
+ * or changes shape, and it is a no-op for any argument the CLI already
+ * generates as nullable (e.g. once this upstream regression is fixed).
+ */
+export const NULLABLE_RPC_ARGUMENTS = {
+  // records.title has no NOT NULL constraint, and both repositories call
+  // these RPCs with `params.title ?? null` / `params.title: string | null`.
+  // records.content has no NOT NULL constraint either, but
+  // `records_text_content_check` requires it to be non-null whenever
+  // record_type = 'text' — append_text_record always inserts 'text', so
+  // p_content there is correctly non-nullable and is intentionally not
+  // listed below.
+  append_media_record: ["p_title", "p_content"],
+  append_text_record: ["p_title"],
+  // conversations.source_id and conversations.cover_image_path are
+  // nullable columns (optional FK / optional cover image); both repository
+  // call sites pass `params.sourceId ?? null` / `params.coverImagePath ?? null`.
+  create_conversation_with_metadata: ["p_source_id", "p_cover_image_path"],
+  // update_conversation_with_metadata is a "diff update" RPC: each p_has_*
+  // flag says whether the corresponding value should be applied at all, so
+  // the value itself is passed as `?? null` from the repository whenever
+  // the field is not being changed (see
+  // supabase/migrations/20260311083000_add_conversation_participants.sql).
+  update_conversation_with_metadata: [
+    "p_title",
+    "p_idol_group",
+    "p_source_id",
+    "p_cover_image_path",
+  ],
+};
+
+/**
+ * Rewrites `argName: SomeType` to `argName: SomeType | null` inside a single
+ * RPC function's `Args: { ... }` block, without touching same-named
+ * arguments in other functions (e.g. `p_title` is non-nullable in
+ * `create_conversation_with_metadata` but nullable in `append_text_record`).
+ * Throws if the function or the argument can't be found, so schema drift
+ * that invalidates this map is caught immediately instead of silently
+ * producing an incorrect committed type.
+ */
+export function markArgumentsNullable(source, functionName, argumentNames) {
+  const blockPattern = new RegExp(
+    `(      ${functionName}: \\{\\n        Args: \\{\\n)([\\s\\S]*?)(\\n        \\}\\n)`,
+  );
+  const blockMatch = source.match(blockPattern);
+  if (!blockMatch) {
+    throw new Error(
+      `db:gen-types: could not find an "Args: { ... }" block for RPC function "${functionName}". ` +
+        "It may have been renamed or removed — update NULLABLE_RPC_ARGUMENTS in scripts/nullable-rpc-arguments.mjs.",
+    );
+  }
+
+  let argsBody = blockMatch[2];
+  for (const argumentName of argumentNames) {
+    const argumentPattern = new RegExp(
+      `(          ${argumentName}: )([^\\n]+)`,
+    );
+    const argumentMatch = argsBody.match(argumentPattern);
+    if (!argumentMatch) {
+      throw new Error(
+        `db:gen-types: could not find argument "${argumentName}" on RPC function "${functionName}". ` +
+          "It may have been renamed or removed — update NULLABLE_RPC_ARGUMENTS in scripts/nullable-rpc-arguments.mjs.",
+      );
+    }
+
+    const currentType = argumentMatch[2];
+    if (currentType.includes("| null")) {
+      // Already nullable (e.g. the upstream CLI regression has been fixed
+      // for this argument) — nothing to patch.
+      continue;
+    }
+
+    argsBody = argsBody.replace(
+      argumentPattern,
+      `$1${currentType} | null`,
+    );
+  }
+
+  return (
+    source.slice(0, blockMatch.index) +
+    blockMatch[1] +
+    argsBody +
+    blockMatch[3] +
+    source.slice(blockMatch.index + blockMatch[0].length)
+  );
+}

--- a/scripts/nullable-rpc-arguments.mjs
+++ b/scripts/nullable-rpc-arguments.mjs
@@ -1,39 +1,36 @@
 /**
- * Known regression (see Issue #123): every "supabase" CLI release we could
- * install and run against this project's local Postgres (2.40.0 through the
- * pinned devDependency version; anything older refuses to talk to Postgres
- * 17 at all) generates every plain RPC argument as non-nullable, regardless
- * of the target column's actual nullability. Postgres itself has no NOT
- * NULL concept for a plain function IN parameter, so `gen types` can only
- * infer nullability heuristically — and the current generator's heuristic
- * always says "non-null".
+ * Issue #123 で確認した既知のリグレッション:
+ * このプロジェクトのローカル Postgres で実行できるすべての Supabase CLI
+ * （2.40.0 から devDependency の固定バージョンまで。これより古いバージョンは
+ * Postgres 17 に接続できない）では、対象カラムの nullable 制約にかかわらず、
+ * 通常の RPC 引数がすべて non-nullable として生成される。
+ * Postgres の通常の関数 IN 引数には NOT NULL という概念がないため、`gen types` は
+ * nullable かどうかを推測するしかなく、現行の生成処理は常に non-null と判定する。
  *
- * The entries below restore `| null` for arguments that this app actually
- * calls with `null` (see the call sites and the schema each maps to). Keep
- * this map in sync with the RPC signatures in `supabase/migrations/`; the
- * post-processing step below fails loudly if a mapped argument disappears
- * or changes shape, and it is a no-op for any argument the CLI already
- * generates as nullable (e.g. once this upstream regression is fixed).
+ * 以下のマップは、アプリが実際に `null` を渡す引数へ `| null` を復元する
+ * （根拠は各呼び出し元と対応するスキーマを参照）。
+ * `supabase/migrations/` の RPC シグネチャと同期して管理すること。
+ * 対象引数が消失または形式変更された場合、後処理は明示的なエラーで停止する。
+ * CLI 側で既に nullable として生成される引数には何もしないため、将来この
+ * リグレッションが修正されても二重に `null` を追加しない。
  */
 export const NULLABLE_RPC_ARGUMENTS = {
-  // records.title has no NOT NULL constraint, and both repositories call
-  // these RPCs with `params.title ?? null` / `params.title: string | null`.
-  // records.content has no NOT NULL constraint either, but
-  // `records_text_content_check` requires it to be non-null whenever
-  // record_type = 'text' — append_text_record always inserts 'text', so
-  // p_content there is correctly non-nullable and is intentionally not
-  // listed below.
+  // records.title には NOT NULL 制約がなく、各 Repository は RPC 呼び出し時に
+  // `params.title ?? null` または `params.title: string | null` を渡す。
+  // records.content にも NOT NULL 制約はないが、`records_text_content_check` により
+  // record_type = 'text' の場合は non-null が必須となる。
+  // append_text_record は常に 'text' を挿入するため、同関数の p_content は
+  // non-nullable が正しく、意図的に以下のマップへ含めていない。
   append_media_record: ["p_title", "p_content"],
   append_text_record: ["p_title"],
-  // conversations.source_id and conversations.cover_image_path are
-  // nullable columns (optional FK / optional cover image); both repository
-  // call sites pass `params.sourceId ?? null` / `params.coverImagePath ?? null`.
+  // conversations.source_id と conversations.cover_image_path は nullable
+  // （任意の外部キー / カバー画像）であり、Repository はそれぞれ
+  // `params.sourceId ?? null` / `params.coverImagePath ?? null` を渡す。
   create_conversation_with_metadata: ["p_source_id", "p_cover_image_path"],
-  // update_conversation_with_metadata is a "diff update" RPC: each p_has_*
-  // flag says whether the corresponding value should be applied at all, so
-  // the value itself is passed as `?? null` from the repository whenever
-  // the field is not being changed (see
-  // supabase/migrations/20260311083000_add_conversation_participants.sql).
+  // update_conversation_with_metadata は差分更新 RPC であり、各 p_has_* が
+  // 対応する値を更新するかどうかを示す。フィールドを変更しない場合、Repository は
+  // 値本体へ `?? null` を適用して渡す
+  // （supabase/migrations/20260311083000_add_conversation_participants.sql 参照）。
   update_conversation_with_metadata: [
     "p_title",
     "p_idol_group",
@@ -43,13 +40,12 @@ export const NULLABLE_RPC_ARGUMENTS = {
 };
 
 /**
- * Rewrites `argName: SomeType` to `argName: SomeType | null` inside a single
- * RPC function's `Args: { ... }` block, without touching same-named
- * arguments in other functions (e.g. `p_title` is non-nullable in
- * `create_conversation_with_metadata` but nullable in `append_text_record`).
- * Throws if the function or the argument can't be found, so schema drift
- * that invalidates this map is caught immediately instead of silently
- * producing an incorrect committed type.
+ * 単一 RPC 関数の `Args: { ... }` ブロック内で、`argName: SomeType` を
+ * `argName: SomeType | null` に書き換える。他の関数にある同名引数は変更しない
+ * （例: `p_title` は `create_conversation_with_metadata` では non-nullable、
+ * `append_text_record` では nullable）。
+ * 関数または引数が見つからない場合は例外を投げ、マップを無効にするスキーマ変更を
+ * 即座に検知する。誤った生成型を黙ってコミットすることを防ぐための fail-fast である。
  */
 export function markArgumentsNullable(source, functionName, argumentNames) {
   const blockPattern = new RegExp(
@@ -78,8 +74,7 @@ export function markArgumentsNullable(source, functionName, argumentNames) {
 
     const currentType = argumentMatch[2];
     if (currentType.includes("| null")) {
-      // Already nullable (e.g. the upstream CLI regression has been fixed
-      // for this argument) — nothing to patch.
+      // CLI 側の修正などですでに nullable の場合は変更しない。
       continue;
     }
 

--- a/scripts/nullable-rpc-arguments.test.mjs
+++ b/scripts/nullable-rpc-arguments.test.mjs
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { markArgumentsNullable } from "./nullable-rpc-arguments.mjs";
+
+// generate-db-types.mjs が supabase CLI から受け取る実際の出力に近いフィクスチャ。
+// append_media_record と append_text_record が同名引数 `p_title` を持つ点が
+// 「関数スコープでしか置換されないこと」を検証する肝になる。
+function createFixtureSource() {
+  return [
+    "export type Database = {",
+    "  public: {",
+    "    Functions: {",
+    "      append_media_record: {",
+    "        Args: {",
+    "          p_content: string",
+    "          p_conversation_id: string",
+    "          p_title: string",
+    "        }",
+    "        Returns: Json",
+    "      }",
+    "      append_text_record: {",
+    "        Args: {",
+    "          p_content: string",
+    "          p_conversation_id: string",
+    "          p_title: string | null",
+    "        }",
+    "        Returns: Json",
+    "      }",
+    "    }",
+    "  }",
+    "}",
+    "",
+  ].join("\n");
+}
+
+describe("markArgumentsNullable", () => {
+  it("rewrites only the targeted argument on the targeted function", () => {
+    const source = createFixtureSource();
+
+    const result = markArgumentsNullable(source, "append_media_record", [
+      "p_title",
+    ]);
+
+    // append_media_record.p_title は書き換えられる。
+    expect(result).toContain(
+      [
+        "      append_media_record: {",
+        "        Args: {",
+        "          p_content: string",
+        "          p_conversation_id: string",
+        "          p_title: string | null",
+        "        }",
+      ].join("\n"),
+    );
+
+    // append_text_record 側の p_content / p_title（同名引数）は不変。
+    expect(result).toContain(
+      [
+        "      append_text_record: {",
+        "        Args: {",
+        "          p_content: string",
+        "          p_conversation_id: string",
+        "          p_title: string | null",
+        "        }",
+      ].join("\n"),
+    );
+
+    // append_media_record.p_content（対象外の引数）は不変。
+    expect(result).toContain("          p_content: string\n");
+  });
+
+  it("is a no-op when the argument is already nullable", () => {
+    const source = createFixtureSource();
+
+    const result = markArgumentsNullable(source, "append_text_record", [
+      "p_title",
+    ]);
+
+    expect(result).toBe(source);
+  });
+
+  it("throws when the target function cannot be found", () => {
+    const source = createFixtureSource();
+
+    expect(() =>
+      markArgumentsNullable(source, "does_not_exist_rpc", ["p_title"]),
+    ).toThrow(/does_not_exist_rpc/);
+  });
+
+  it("throws when the target argument cannot be found on the function", () => {
+    const source = createFixtureSource();
+
+    expect(() =>
+      markArgumentsNullable(source, "append_media_record", [
+        "p_does_not_exist",
+      ]),
+    ).toThrow(/p_does_not_exist/);
+  });
+});


### PR DESCRIPTION
## Why / Background
- #114 のレビュー過程で発覚した技術的負債（#123）: `pnpm db:gen-types` の Supabase CLI がバージョン非固定で、生成される `src/types/database.ts` が実行環境により変わる。RPC の nullable 引数は手動パッチで維持されており、再生成すると typecheck が壊れる状態だった

## What / Summary
- **調査結果（重要）**: PG17 互換の全 CLI バージョン（2.40.0〜2.109.1）で RPC 引数は non-nullable 生成だった。つまりコミット済みの nullable パターンはどの CLI も生成したことがない「暗黙の手動パッチ」であり、「正しいバージョンに固定する」では解決できないと判明
- 方針B を採用: `scripts/generate-db-types.mjs` に **`NULLABLE_RPC_ARGUMENTS` マップ駆動の後処理**を追加
  - 関数スコープで置換（他関数の同名引数を誤爆しない）
  - 各エントリに根拠コメント（対象カラムの nullable 制約・CHECK 制約・repository の実呼び出し）
  - マップ対象の関数・引数が生成結果に見つからない場合は**例外で停止**（スキーマドリフトの早期検知）
  - 既に nullable なら no-op（将来 CLI 側の修正が入っても壊れない）
- `supabase` CLI を devDependencies に **2.109.1 固定（キャレットなし）**で追加（`npx supabase ...` がローカル固定版を解決するため、スクリプト・skills のコマンド記述は変更不要）
- `docs/development.md` に「DB型生成」節を新設、migration スキルに RPC 引数変更時のマップ更新義務を追記

## Scope / Impact
- 影響する画面・API・データ：なし（開発ツールとドキュメントのみ。`src/types/database.ts` の内容は不変）
- 影響しないもの：アプリの実行時挙動すべて
- 破壊的変更（Breaking change）：なし

## Related Issues
- Closes #123
- Related #114（発覚元）

## DB / Migration（DB変更があるときだけ）
- 変更なし

## Test Plan
- [x] `pnpm db:gen-types` 1回目: コミット済み `database.ts` と**差分ゼロ**（手動パッチと同内容が自動生成される）
- [x] `pnpm db:gen-types` 2回目: 差分ゼロ（冪等）
- [x] `npx supabase --version` = 2.109.1（固定版が解決される）/ `npx supabase db reset` 成功（全 migration + seed）
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test`（73 files / 654 tests）通過
- [x] 上記検証は実装担当（Sonnet サブエージェント）とレビュー担当（Fable）がそれぞれ独立に実行して一致を確認

## Screenshots (UI changes only)
- UI 変更なし

## Review Notes（レビュワー向け）
- 見てほしい点（優先順に）：
  1. `NULLABLE_RPC_ARGUMENTS` の各エントリの根拠（コメント記載）が実際のスキーマ・呼び出しと整合しているか
  2. マップ陳腐化時に「例外で停止」させる強めの挙動の妥当性（静かなドリフトより早期検知を優先した。緩めるなら警告ログ化も可能）
- 不安な点 / 判断が欲しい点：
  - CLI 固定版は動作確認済みの最新 2.109.1 を採用（後処理が nullable を吸収するため、バージョン選定は他コマンドの互換性を優先）
- 既知の制限 / 今後やること：
  - CLI 側の nullable 生成が上流で修正された場合、後処理は no-op になりマップは自然に不要化する（削除は任意）

## Checklist
- [x] `.env*` や秘密情報を含まない
- [x] 例外系（空/NULL/境界値）を考慮した（マップ対象消失時の fail-fast）
- [x] 影響範囲に対してテスト項目が十分
- [x] 破壊的変更がある場合、移行手順を記載した（破壊的変更なし）

---
🤖 Generated with Claude Code / ✅ Human-checked: @kikun-dev
