### PR TITLE
feat: 本文中のURLをリンク表示する

### DIFF
--- a/src/components/ChatMessage.test.tsx
+++ b/src/components/ChatMessage.test.tsx
@@ -293,6 +293,28 @@ describe("ChatMessage", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders a URL in content as a clickable link", () => {
+    const record = {
+      ...textRecord,
+      content: "資料はこちら https://example.com/doc をどうぞ",
+    };
+    render(
+      <ToastProvider><ChatMessage
+        record={record}
+        participantName="メンバーA"
+        conversationId="conv-1"
+        displayName=""
+      /></ToastProvider>,
+    );
+
+    const link = screen.getByRole("link", {
+      name: "https://example.com/doc",
+    });
+    expect(link).toHaveAttribute("href", "https://example.com/doc");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
   it("shows raw placeholder in edit mode textarea", () => {
     const record = {
       ...textRecord,

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -15,6 +15,7 @@ import {
   type MediaFileKind,
 } from "@/lib/mediaFileSelection";
 import { FormError } from "@/components/FormError";
+import { LinkifiedText } from "@/components/LinkifiedText";
 import { useToast } from "@/components/ToastProvider";
 import type { Record } from "@/types/domain";
 import type { MediaUrl } from "@/usecases/recordUseCases";
@@ -343,7 +344,9 @@ export const ChatMessage = memo(function ChatMessage({
           )}
           {record.content && (
             <p className="whitespace-pre-wrap text-sm text-gray-700">
-              {replaceMyNamePlaceholder(record.content, displayName)}
+              <LinkifiedText
+                text={replaceMyNamePlaceholder(record.content, displayName)}
+              />
             </p>
           )}
           {mediaUrl && <MediaContent record={record} mediaUrl={mediaUrl} />}

--- a/src/components/LinkifiedText.test.tsx
+++ b/src/components/LinkifiedText.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { LinkifiedText } from "./LinkifiedText";
+
+describe("LinkifiedText", () => {
+  it("renders plain text without a URL as-is", () => {
+    const { container } = render(<LinkifiedText text="こんにちは" />);
+
+    expect(container.textContent).toBe("こんにちは");
+    expect(container.querySelector("a")).not.toBeInTheDocument();
+  });
+
+  it("renders a URL as an anchor with target and rel attributes", () => {
+    render(<LinkifiedText text="見て https://example.com すごい" />);
+
+    const link = screen.getByRole("link", { name: "https://example.com" });
+    expect(link).toHaveAttribute("href", "https://example.com");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("renders surrounding text alongside the link", () => {
+    const { container } = render(
+      <LinkifiedText text="見て https://example.com すごい" />,
+    );
+
+    expect(container.textContent).toBe("見て https://example.com すごい");
+  });
+
+  it("renders multiple links", () => {
+    render(
+      <LinkifiedText text="https://example.com と https://example.org を見て" />,
+    );
+
+    expect(
+      screen.getByRole("link", { name: "https://example.com" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "https://example.org" }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps trailing punctuation out of the link", () => {
+    const { container } = render(
+      <LinkifiedText text="詳細はhttps://example.com。" />,
+    );
+
+    const link = screen.getByRole("link", { name: "https://example.com" });
+    expect(link).toHaveAttribute("href", "https://example.com");
+    expect(container.textContent).toBe("詳細はhttps://example.com。");
+  });
+});

--- a/src/components/LinkifiedText.tsx
+++ b/src/components/LinkifiedText.tsx
@@ -1,0 +1,30 @@
+import { Fragment } from "react";
+import { splitTextByUrls } from "@/usecases/contentTransform";
+
+type LinkifiedTextProps = {
+  text: string;
+};
+
+export function LinkifiedText({ text }: LinkifiedTextProps) {
+  const segments = splitTextByUrls(text);
+
+  return (
+    <>
+      {segments.map((segment, index) =>
+        segment.type === "url" ? (
+          <a
+            key={index}
+            href={segment.value}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="break-all text-blue-600 underline"
+          >
+            {segment.value}
+          </a>
+        ) : (
+          <Fragment key={index}>{segment.value}</Fragment>
+        ),
+      )}
+    </>
+  );
+}

--- a/src/components/RecordCard.tsx
+++ b/src/components/RecordCard.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { LinkifiedText } from "@/components/LinkifiedText";
 import { formatDateTimeJst } from "@/lib/dateTime";
 import type { Record, RecordType } from "@/types/domain";
 import type { MediaUrl } from "@/usecases/recordUseCases";
@@ -81,7 +82,7 @@ export function RecordCard({ record, mediaUrl }: RecordCardProps) {
       </div>
       {record.content && (
         <p className="mt-2 whitespace-pre-wrap text-sm text-gray-700">
-          {record.content}
+          <LinkifiedText text={record.content} />
         </p>
       )}
       {mediaUrl && <MediaDisplay record={record} mediaUrl={mediaUrl} />}

--- a/src/usecases/contentTransform.test.ts
+++ b/src/usecases/contentTransform.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { replaceMyNamePlaceholder } from "./contentTransform";
+import { replaceMyNamePlaceholder, splitTextByUrls } from "./contentTransform";
 
 describe("replaceMyNamePlaceholder", () => {
   it("replaces {{MY_NAME}} with display name", () => {
@@ -41,5 +41,97 @@ describe("replaceMyNamePlaceholder", () => {
 
   it("handles placeholder only", () => {
     expect(replaceMyNamePlaceholder("{{MY_NAME}}", "太郎")).toBe("太郎");
+  });
+});
+
+describe("splitTextByUrls", () => {
+  it("returns a single text segment when there is no URL", () => {
+    expect(splitTextByUrls("こんにちは")).toEqual([
+      { type: "text", value: "こんにちは" },
+    ]);
+  });
+
+  it("returns a single url segment when the text is only a URL", () => {
+    expect(splitTextByUrls("https://example.com")).toEqual([
+      { type: "url", value: "https://example.com" },
+    ]);
+  });
+
+  it("splits text surrounding a URL", () => {
+    expect(splitTextByUrls("見て https://example.com すごい")).toEqual([
+      { type: "text", value: "見て " },
+      { type: "url", value: "https://example.com" },
+      { type: "text", value: " すごい" },
+    ]);
+  });
+
+  it("splits multiple URLs", () => {
+    expect(
+      splitTextByUrls(
+        "https://example.com と https://example.org を見て",
+      ),
+    ).toEqual([
+      { type: "url", value: "https://example.com" },
+      { type: "text", value: " と " },
+      { type: "url", value: "https://example.org" },
+      { type: "text", value: " を見て" },
+    ]);
+  });
+
+  it("terminates a URL at a line break", () => {
+    expect(splitTextByUrls("見て\nhttps://example.com\n見た？")).toEqual([
+      { type: "text", value: "見て\n" },
+      { type: "url", value: "https://example.com" },
+      { type: "text", value: "\n見た？" },
+    ]);
+  });
+
+  it("moves trailing Japanese punctuation back to the text segment", () => {
+    expect(splitTextByUrls("見て。https://example.com。")).toEqual([
+      { type: "text", value: "見て。" },
+      { type: "url", value: "https://example.com" },
+      { type: "text", value: "。" },
+    ]);
+  });
+
+  it("moves a trailing closing bracket back to the text segment", () => {
+    expect(splitTextByUrls("（詳細はhttps://example.com）")).toEqual([
+      { type: "text", value: "（詳細は" },
+      { type: "url", value: "https://example.com" },
+      { type: "text", value: "）" },
+    ]);
+  });
+
+  it("moves other trailing punctuation marks back to the text segment", () => {
+    const cases: Array<[string, string]> = [
+      ["https://example.com、", "、"],
+      ["https://example.com」", "」"],
+      ["https://example.com！", "！"],
+      ["https://example.com？", "？"],
+      ["https://example.com!", "!"],
+      ["https://example.com?", "?"],
+      ["https://example.com,", ","],
+      ["https://example.com.", "."],
+      ["https://example.com;", ";"],
+      ["https://example.com:", ":"],
+      ["https://example.com)", ")"],
+    ];
+
+    for (const [input, trailing] of cases) {
+      expect(splitTextByUrls(input)).toEqual([
+        { type: "url", value: "https://example.com" },
+        { type: "text", value: trailing },
+      ]);
+    }
+  });
+
+  it("supports http as well as https", () => {
+    expect(splitTextByUrls("http://example.com")).toEqual([
+      { type: "url", value: "http://example.com" },
+    ]);
+  });
+
+  it("returns an empty array for empty text", () => {
+    expect(splitTextByUrls("")).toEqual([]);
   });
 });

--- a/src/usecases/contentTransform.test.ts
+++ b/src/usecases/contentTransform.test.ts
@@ -134,4 +134,16 @@ describe("splitTextByUrls", () => {
   it("returns an empty array for empty text", () => {
     expect(splitTextByUrls("")).toEqual([]);
   });
+
+  it("linkifies an uppercase scheme while preserving the original casing", () => {
+    expect(splitTextByUrls("HTTPS://example.com/x")).toEqual([
+      { type: "url", value: "HTTPS://example.com/x" },
+    ]);
+  });
+
+  it("linkifies a mixed-case scheme", () => {
+    expect(splitTextByUrls("Http://example.com")).toEqual([
+      { type: "url", value: "Http://example.com" },
+    ]);
+  });
 });

--- a/src/usecases/contentTransform.ts
+++ b/src/usecases/contentTransform.ts
@@ -13,7 +13,7 @@ export type TextSegment = { type: "text" | "url"; value: string };
 // URL 末尾に付きがちな句読点・記号は URL に含めず、後続のテキストへ戻す
 const TRAILING_PUNCTUATION = /[。、）」！？!?,.;:)]+$/;
 
-const URL_PATTERN = /https?:\/\/\S+/g;
+const URL_PATTERN = /https?:\/\/\S+/gi;
 
 export function splitTextByUrls(text: string): TextSegment[] {
   if (text.length === 0) return [];

--- a/src/usecases/contentTransform.ts
+++ b/src/usecases/contentTransform.ts
@@ -7,3 +7,43 @@ export function replaceMyNamePlaceholder(
   if (displayName.length === 0) return text;
   return text.replaceAll(MY_NAME_PLACEHOLDER, displayName);
 }
+
+export type TextSegment = { type: "text" | "url"; value: string };
+
+// URL 末尾に付きがちな句読点・記号は URL に含めず、後続のテキストへ戻す
+const TRAILING_PUNCTUATION = /[。、）」！？!?,.;:)]+$/;
+
+const URL_PATTERN = /https?:\/\/\S+/g;
+
+export function splitTextByUrls(text: string): TextSegment[] {
+  if (text.length === 0) return [];
+
+  const segments: TextSegment[] = [];
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(URL_PATTERN)) {
+    const matchStart = match.index;
+    let rawUrl = match[0];
+
+    const trailingMatch = rawUrl.match(TRAILING_PUNCTUATION);
+    const trailing = trailingMatch ? trailingMatch[0] : "";
+    if (trailing.length > 0) {
+      rawUrl = rawUrl.slice(0, rawUrl.length - trailing.length);
+    }
+
+    if (rawUrl.length === 0) continue;
+
+    if (matchStart > lastIndex) {
+      segments.push({ type: "text", value: text.slice(lastIndex, matchStart) });
+    }
+    segments.push({ type: "url", value: rawUrl });
+
+    lastIndex = matchStart + rawUrl.length;
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ type: "text", value: text.slice(lastIndex) });
+  }
+
+  return segments;
+}


### PR DESCRIPTION
## Why / Background
- メール由来のトークは本文に URL を含むことが多い（実メール41通中21通）が、プレーンテキスト表示のためタップで開けない（Issue #130、.eml 一括取込の実運用フィードバック）

## What / Summary
- UseCase 層に純粋関数 `splitTextByUrls(text): TextSegment[]` を追加（`https?://` を URL セグメントとして分割。末尾の句読点・閉じ括弧 `。、）」！？!?,.;:)` は URL に含めず後続テキストへ戻す）
- `LinkifiedText` コンポーネントを新規追加し、タイムライン（`ChatMessage`）と検索結果カード（`RecordCard`）の本文に適用
  - React 要素として描画（`dangerouslySetInnerHTML` 不使用 = XSS 安全）
  - リンクは `target="_blank"` + `rel="noopener noreferrer"`、`break-all` で折り返し
  - `ChatMessage` 側は `replaceMyNamePlaceholder` 適用**後**のテキストを分割（プレースホルダー置換とリンク化の順序を固定）
  - テキストセグメントは `Fragment` で素のテキストノードのまま描画（既存テストの `getByText` 完全一致を壊さない）

## Scope / Impact
- 影響する画面・API・データ：タイムラインの本文表示、検索結果カードの本文表示（表示のみ）
- 影響しないもの：タイトル表示（URL の実例なし・Non-goal）、データ・API・編集フロー
- 破壊的変更（Breaking change）：なし

## Related Issues
- Closes #130

## DB / Migration（DB変更があるときだけ）
- [ ] マイグレーションなし

## Test Plan
- [x] 自動テスト（TDD、+17 テスト）
  - `splitTextByUrls`: URL なし / URL のみ / 前後テキスト / 複数 URL / 改行直後 / 末尾句読点（text に戻る）/ http・https / 空文字（11件）
  - `LinkifiedText`: href・target・rel 属性、テキスト部分の素通し（5件）
  - `ChatMessage`: content 中の URL がリンクとして描画される結合テスト（1件）
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test`（76 files / 757 tests）/ `pnpm build` 通過
- [ ] 未実施: 実ブラウザでのタップ確認（デプロイプレビューで確認可能）

## Screenshots (UI changes only)
- Before：URL がプレーンテキスト表示
- After：URL が下線付きリンク（新しいタブで開く）

## Review Notes（レビュワー向け）
- 見てほしい点（優先順に）：
  1. `splitTextByUrls` の末尾句読点の扱い（URL 内に正当な `)` を含むケースは誤って削るトレードオフを許容。メール由来 URL では実害なしと判断）
  2. リンク描画のセキュリティ（href は `https?://` マッチのみ・要素描画・`rel="noopener noreferrer"`）
- 既知の制限 / 今後やること：
  - `www.` 始まりなどスキームなし URL は対象外（Non-goal）

## Checklist
- [x] `.env*` や秘密情報を含まない
- [x] 例外系（空/NULL/境界値）を考慮した（空文字・URL のみ・末尾句読点・複数 URL）
- [x] 影響範囲に対してテスト項目が十分
- [x] 破壊的変更がある場合、移行手順を記載した（破壊的変更なし）

---
🤖 Generated with Claude Code / ✅ Human-checked: @kikun-dev
