### PR TITLE
fix: レコード・トーク削除時にStorageファイルが孤立する問題を修正

### DIFF
--- a/src/app/(app)/conversations/[id]/actions.test.ts
+++ b/src/app/(app)/conversations/[id]/actions.test.ts
@@ -428,8 +428,23 @@ describe("deleteConversationAction", () => {
     const result = await deleteConversationAction("conv-1");
 
     expect(result).toEqual({
-      error:
+      warning:
         "トークは削除しましたが、メディアファイルの削除に失敗しました。",
+    });
+    expect(redirectMock).not.toHaveBeenCalled();
+    expect(revalidatePathMock).toHaveBeenCalledWith("/");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/conversations/conv-1");
+  });
+
+  it("returns an error without redirecting when db deletion fails", async () => {
+    mockSupabaseClient({ id: "user-1" });
+    deleteExistingConversationMock.mockRejectedValue(new Error("DB error"));
+
+    const { deleteConversationAction } = await import("./actions");
+    const result = await deleteConversationAction("conv-1");
+
+    expect(result).toEqual({
+      error: "会話の削除に失敗しました。時間をおいて再度お試しください。",
     });
     expect(redirectMock).not.toHaveBeenCalled();
   });
@@ -537,10 +552,22 @@ describe("deleteRecordAction", () => {
     const result = await deleteRecordAction("conv-1", "rec-1");
 
     expect(result).toEqual({
-      error:
+      warning:
         "レコードは削除しましたが、メディアファイルの削除に失敗しました。",
     });
     expect(revalidatePathMock).toHaveBeenCalledWith("/conversations/conv-1");
+  });
+
+  it("returns an error when db deletion fails", async () => {
+    mockSupabaseClient({ id: "user-1" });
+    deleteExistingRecordMock.mockRejectedValue(new Error("DB error"));
+
+    const { deleteRecordAction } = await import("./actions");
+    const result = await deleteRecordAction("conv-1", "rec-1");
+
+    expect(result).toEqual({
+      error: "レコードの削除に失敗しました。時間をおいて再度お試しください。",
+    });
   });
 });
 

--- a/src/app/(app)/conversations/[id]/actions.test.ts
+++ b/src/app/(app)/conversations/[id]/actions.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { StorageCleanupError } from "@/usecases/storageCleanupError";
 
 const getUserMock = vi.fn();
 const createSupabaseServerClientMock = vi.fn();
@@ -413,7 +414,24 @@ describe("deleteConversationAction", () => {
     expect(deleteExistingConversationMock).toHaveBeenCalledWith(
       expect.anything(),
       "conv-1",
+      "user-1",
     );
+  });
+
+  it("returns a warning without redirecting when storage cleanup fails", async () => {
+    mockSupabaseClient({ id: "user-1" });
+    deleteExistingConversationMock.mockRejectedValue(
+      new StorageCleanupError("cleanup failed"),
+    );
+
+    const { deleteConversationAction } = await import("./actions");
+    const result = await deleteConversationAction("conv-1");
+
+    expect(result).toEqual({
+      error:
+        "トークは削除しましたが、メディアファイルの削除に失敗しました。",
+    });
+    expect(redirectMock).not.toHaveBeenCalled();
   });
 });
 
@@ -504,7 +522,24 @@ describe("deleteRecordAction", () => {
     expect(deleteExistingRecordMock).toHaveBeenCalledWith(
       expect.anything(),
       "rec-1",
+      "user-1",
     );
+    expect(revalidatePathMock).toHaveBeenCalledWith("/conversations/conv-1");
+  });
+
+  it("revalidates and returns a warning when storage cleanup fails", async () => {
+    mockSupabaseClient({ id: "user-1" });
+    deleteExistingRecordMock.mockRejectedValue(
+      new StorageCleanupError("cleanup failed"),
+    );
+
+    const { deleteRecordAction } = await import("./actions");
+    const result = await deleteRecordAction("conv-1", "rec-1");
+
+    expect(result).toEqual({
+      error:
+        "レコードは削除しましたが、メディアファイルの削除に失敗しました。",
+    });
     expect(revalidatePathMock).toHaveBeenCalledWith("/conversations/conv-1");
   });
 });

--- a/src/app/(app)/conversations/[id]/actions.ts
+++ b/src/app/(app)/conversations/[id]/actions.ts
@@ -840,7 +840,7 @@ export async function updateConversationCoverImageAction(
 
 export async function deleteConversationAction(
   conversationId: string,
-): Promise<{ error: string } | void> {
+): Promise<{ error: string } | { warning: string } | void> {
   const supabase = await createSupabaseServerClient();
   const {
     data: { user },
@@ -855,8 +855,10 @@ export async function deleteConversationAction(
   } catch (error) {
     if (error instanceof StorageCleanupError) {
       console.error("Failed to clean up storage for conversation:", error);
+      revalidatePath("/");
+      revalidatePath(`/conversations/${conversationId}`);
       return {
-        error:
+        warning:
           "トークは削除しましたが、メディアファイルの削除に失敗しました。",
       };
     }
@@ -917,7 +919,7 @@ export async function updateRecordAction(
 export async function deleteRecordAction(
   conversationId: string,
   recordId: string,
-): Promise<{ error: string } | void> {
+): Promise<{ error: string } | { warning: string } | void> {
   const supabase = await createSupabaseServerClient();
   const {
     data: { user },
@@ -934,7 +936,7 @@ export async function deleteRecordAction(
       console.error("Failed to clean up storage for record:", error);
       revalidatePath(`/conversations/${conversationId}`);
       return {
-        error:
+        warning:
           "レコードは削除しましたが、メディアファイルの削除に失敗しました。",
       };
     }

--- a/src/app/(app)/conversations/[id]/actions.ts
+++ b/src/app/(app)/conversations/[id]/actions.ts
@@ -29,6 +29,7 @@ import {
   validateUpdateRecordInput,
   deleteExistingRecord,
 } from "@/usecases/recordUseCases";
+import { StorageCleanupError } from "@/usecases/storageCleanupError";
 import type { RecordType } from "@/types/domain";
 
 export type ActionState =
@@ -850,8 +851,15 @@ export async function deleteConversationAction(
   }
 
   try {
-    await deleteExistingConversation(supabase, conversationId);
+    await deleteExistingConversation(supabase, conversationId, user.id);
   } catch (error) {
+    if (error instanceof StorageCleanupError) {
+      console.error("Failed to clean up storage for conversation:", error);
+      return {
+        error:
+          "トークは削除しましたが、メディアファイルの削除に失敗しました。",
+      };
+    }
     console.error("Failed to delete conversation:", error);
     return { error: "会話の削除に失敗しました。時間をおいて再度お試しください。" };
   }
@@ -920,8 +928,16 @@ export async function deleteRecordAction(
   }
 
   try {
-    await deleteExistingRecord(supabase, recordId);
+    await deleteExistingRecord(supabase, recordId, user.id);
   } catch (error) {
+    if (error instanceof StorageCleanupError) {
+      console.error("Failed to clean up storage for record:", error);
+      revalidatePath(`/conversations/${conversationId}`);
+      return {
+        error:
+          "レコードは削除しましたが、メディアファイルの削除に失敗しました。",
+      };
+    }
     console.error("Failed to delete record:", error);
     return { error: "レコードの削除に失敗しました。時間をおいて再度お試しください。" };
   }

--- a/src/app/(app)/conversations/[id]/overview/page.test.tsx
+++ b/src/app/(app)/conversations/[id]/overview/page.test.tsx
@@ -30,6 +30,7 @@ vi.mock("@/app/(app)/conversations/[id]/actions", () => ({
 vi.mock("next/navigation", () => ({
   redirect: redirectMock,
   notFound: notFoundMock,
+  useRouter: () => ({ replace: vi.fn() }),
 }));
 
 const conversation: ConversationWithRecords = {

--- a/src/components/ChatMessage.test.tsx
+++ b/src/components/ChatMessage.test.tsx
@@ -10,7 +10,10 @@ vi.mock("@/app/(app)/conversations/[id]/actions", () => ({
   attachRecordMediaAction: vi.fn(),
 }));
 
-import { attachRecordMediaAction } from "@/app/(app)/conversations/[id]/actions";
+import {
+  attachRecordMediaAction,
+  deleteRecordAction,
+} from "@/app/(app)/conversations/[id]/actions";
 
 const textRecord: Record = {
   id: "rec-1",
@@ -240,6 +243,33 @@ describe("ChatMessage", () => {
     expect(actionButton).toHaveAttribute("aria-expanded", "true");
     expect(within(menu).getByText("編集")).toBeInTheDocument();
     expect(within(menu).getByText("削除")).toBeInTheDocument();
+  });
+
+  it("shows a warning toast when deleting a record leaves storage cleanup failed", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(deleteRecordAction).mockResolvedValue({
+      warning:
+        "レコードは削除しましたが、メディアファイルの削除に失敗しました。",
+    });
+
+    render(
+      <ToastProvider><ChatMessage
+        record={textRecord}
+        participantName="メンバーA"
+        conversationId="conv-1"
+        isEditMode
+        displayName=""
+      /></ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "操作" }));
+    fireEvent.click(within(screen.getByRole("menu")).getByText("削除"));
+
+    expect(
+      await screen.findByText(
+        "レコードは削除しましたが、メディアファイルの削除に失敗しました。",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("hides action menu trigger outside edit mode", () => {

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -235,9 +235,14 @@ export const ChatMessage = memo(function ChatMessage({
     if (!window.confirm("このレコードを削除しますか？")) return;
     startDeleteTransition(async () => {
       const result = await deleteRecordAction(conversationId, record.id);
-      if (result?.error) {
-        addToast(result.error, "error");
+      if (!result) {
+        return;
       }
+      if ("error" in result) {
+        addToast(result.error, "error");
+        return;
+      }
+      addToast(result.warning, "warning");
     });
   }
 

--- a/src/components/ConversationActions.test.tsx
+++ b/src/components/ConversationActions.test.tsx
@@ -11,6 +11,10 @@ vi.mock("@/app/(app)/conversations/[id]/actions", () => ({
   updateConversationCoverImageAction: vi.fn(),
 }));
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+}));
+
 const conversation: ConversationWithMetadata = {
   id: "conv-1",
   userId: "user-1",

--- a/src/components/DeleteConversationButton.test.tsx
+++ b/src/components/DeleteConversationButton.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { DeleteConversationButton } from "./DeleteConversationButton";
+import { ToastProvider } from "./ToastProvider";
+
+vi.mock("@/app/(app)/conversations/[id]/actions", () => ({
+  deleteConversationAction: vi.fn(),
+}));
+
+const replaceMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: replaceMock }),
+}));
+
+import { deleteConversationAction } from "@/app/(app)/conversations/[id]/actions";
+
+describe("DeleteConversationButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+  });
+
+  it("shows an error toast and does not navigate when deletion fails", async () => {
+    vi.mocked(deleteConversationAction).mockResolvedValue({
+      error: "会話の削除に失敗しました。時間をおいて再度お試しください。",
+    });
+
+    render(
+      <ToastProvider>
+        <DeleteConversationButton conversationId="conv-1" />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByText("会話を削除"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "会話の削除に失敗しました。時間をおいて再度お試しください。",
+        ),
+      ).toBeInTheDocument();
+    });
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("shows a warning toast and navigates home when storage cleanup fails", async () => {
+    vi.mocked(deleteConversationAction).mockResolvedValue({
+      warning:
+        "トークは削除しましたが、メディアファイルの削除に失敗しました。",
+    });
+
+    render(
+      <ToastProvider>
+        <DeleteConversationButton conversationId="conv-1" />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByText("会話を削除"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "トークは削除しましたが、メディアファイルの削除に失敗しました。",
+        ),
+      ).toBeInTheDocument();
+    });
+    expect(replaceMock).toHaveBeenCalledWith("/");
+  });
+
+  it("does nothing when the user cancels the confirmation", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    render(
+      <ToastProvider>
+        <DeleteConversationButton conversationId="conv-1" />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByText("会話を削除"));
+
+    expect(deleteConversationAction).not.toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/DeleteConversationButton.tsx
+++ b/src/components/DeleteConversationButton.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useTransition } from "react";
 import { deleteConversationAction } from "@/app/(app)/conversations/[id]/actions";
 import { useToast } from "@/components/ToastProvider";
@@ -13,6 +14,7 @@ export function DeleteConversationButton({
 }: DeleteConversationButtonProps) {
   const [isPending, startTransition] = useTransition();
   const { addToast } = useToast();
+  const router = useRouter();
 
   function handleDelete() {
     if (!window.confirm("この会話を削除しますか？関連するレコードもすべて削除されます。")) {
@@ -21,9 +23,16 @@ export function DeleteConversationButton({
 
     startTransition(async () => {
       const result = await deleteConversationAction(conversationId);
-      if (result?.error) {
-        addToast(result.error, "error");
+      if (!result) {
+        return;
       }
+      if ("error" in result) {
+        addToast(result.error, "error");
+        return;
+      }
+      // 部分成功: トークは削除済みのためホームへ遷移する
+      addToast(result.warning, "warning");
+      router.replace("/");
     });
   }
 

--- a/src/components/EditableRecordCard.test.tsx
+++ b/src/components/EditableRecordCard.test.tsx
@@ -9,6 +9,8 @@ vi.mock("@/app/(app)/conversations/[id]/actions", () => ({
   deleteRecordAction: vi.fn(),
 }));
 
+import { deleteRecordAction } from "@/app/(app)/conversations/[id]/actions";
+
 const textRecord: Record = {
   id: "rec-1",
   conversationId: "conv-1",
@@ -86,5 +88,25 @@ describe("EditableRecordCard", () => {
 
     expect(screen.getByText("テストタイトル")).toBeInTheDocument();
     expect(screen.getByText("編集")).toBeInTheDocument();
+  });
+
+  it("shows a warning toast when deleting a record leaves storage cleanup failed", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(deleteRecordAction).mockResolvedValue({
+      warning:
+        "レコードは削除しましたが、メディアファイルの削除に失敗しました。",
+    });
+
+    render(
+      <ToastProvider><EditableRecordCard record={textRecord} conversationId="conv-1" /></ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByText("削除"));
+
+    expect(
+      await screen.findByText(
+        "レコードは削除しましたが、メディアファイルの削除に失敗しました。",
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/EditableRecordCard.tsx
+++ b/src/components/EditableRecordCard.tsx
@@ -50,9 +50,14 @@ export function EditableRecordCard({
 
     startDeleteTransition(async () => {
       const result = await deleteRecordAction(conversationId, record.id);
-      if (result?.error) {
-        addToast(result.error, "error");
+      if (!result) {
+        return;
       }
+      if ("error" in result) {
+        addToast(result.error, "error");
+        return;
+      }
+      addToast(result.warning, "warning");
     });
   }
 

--- a/src/components/Toast.test.tsx
+++ b/src/components/Toast.test.tsx
@@ -32,6 +32,21 @@ describe("Toast", () => {
     expect(alert.className).toContain("border-green-200");
   });
 
+  it("renders message with warning styling", () => {
+    const onDismiss = vi.fn();
+    render(
+      <Toast
+        id="t4"
+        message="一部の処理に失敗しました"
+        type="warning"
+        onDismiss={onDismiss}
+      />,
+    );
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toContain("一部の処理に失敗しました");
+    expect(alert.className).toContain("border-amber-200");
+  });
+
   it("calls onDismiss when close button is clicked", () => {
     const onDismiss = vi.fn();
     render(

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,4 +1,4 @@
-type ToastType = "success" | "error";
+type ToastType = "success" | "error" | "warning";
 
 type ToastProps = {
   id: string;
@@ -12,6 +12,8 @@ const typeStyles: Record<ToastType, string> = {
     "border-green-200 bg-green-50 text-green-800",
   error:
     "border-red-200 bg-red-50 text-red-800",
+  warning:
+    "border-amber-200 bg-amber-50 text-amber-800",
 };
 
 export function Toast({ id, message, type, onDismiss }: ToastProps) {

--- a/src/components/ToastProvider.test.tsx
+++ b/src/components/ToastProvider.test.tsx
@@ -12,6 +12,9 @@ function TestConsumer() {
       <button onClick={() => addToast("失敗しました", "error")}>
         error
       </button>
+      <button onClick={() => addToast("一部失敗しました", "warning")}>
+        warning
+      </button>
     </div>
   );
 }
@@ -50,6 +53,17 @@ describe("ToastProvider", () => {
 
     fireEvent.click(screen.getByText("error"));
     expect(screen.getByText("失敗しました")).toBeDefined();
+  });
+
+  it("shows warning toast", () => {
+    render(
+      <ToastProvider>
+        <TestConsumer />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByText("warning"));
+    expect(screen.getByText("一部失敗しました")).toBeDefined();
   });
 
   it("dismisses toast when close button clicked", () => {

--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -12,7 +12,7 @@ import {
 import { createPortal } from "react-dom";
 import { Toast } from "@/components/Toast";
 
-type ToastType = "success" | "error";
+type ToastType = "success" | "error" | "warning";
 
 type ToastItem = {
   id: string;

--- a/src/repositories/attachmentRepository.test.ts
+++ b/src/repositories/attachmentRepository.test.ts
@@ -5,6 +5,7 @@ import {
   getAttachmentsByRecord,
   getAttachmentsByRecordIds,
   getAttachmentsByType,
+  getAttachmentFilePathsByConversation,
   createAttachment,
   deleteAttachment,
 } from "./attachmentRepository";
@@ -240,6 +241,50 @@ describe("attachmentRepository", () => {
 
       await expect(
         getAttachmentsByType(client, "user-1", "image"),
+      ).rejects.toEqual(dbError);
+    });
+  });
+
+  describe("getAttachmentFilePathsByConversation", () => {
+    it("returns file paths joined via records in a single query", async () => {
+      builder = createMockQueryBuilder({
+        eq: vi.fn().mockResolvedValue({
+          data: [
+            { file_path: "user-1/conv-1/rec-1/photo.jpg" },
+            { file_path: "user-1/conv-1/rec-2/video.mp4" },
+          ],
+          error: null,
+        }),
+      });
+      client = createMockClient(builder);
+
+      const result = await getAttachmentFilePathsByConversation(
+        client,
+        "conv-1",
+      );
+
+      expect(result).toEqual([
+        "user-1/conv-1/rec-1/photo.jpg",
+        "user-1/conv-1/rec-2/video.mp4",
+      ]);
+      expect(builder.select).toHaveBeenCalledWith(
+        "file_path, records!inner(conversation_id)",
+      );
+      expect(builder.eq).toHaveBeenCalledWith(
+        "records.conversation_id",
+        "conv-1",
+      );
+    });
+
+    it("throws on error", async () => {
+      const dbError = { message: "DB error", code: "42000" };
+      builder = createMockQueryBuilder({
+        eq: vi.fn().mockResolvedValue({ data: null, error: dbError }),
+      });
+      client = createMockClient(builder);
+
+      await expect(
+        getAttachmentFilePathsByConversation(client, "conv-1"),
       ).rejects.toEqual(dbError);
     });
   });

--- a/src/repositories/attachmentRepository.ts
+++ b/src/repositories/attachmentRepository.ts
@@ -67,6 +67,24 @@ export async function getAttachmentsByRecordIds(
   return data.map(toAttachment);
 }
 
+export async function getAttachmentFilePathsByConversation(
+  client: SupabaseClient<Database>,
+  conversationId: string,
+): Promise<string[]> {
+  const { data, error } = await client
+    .from("attachments")
+    .select("file_path, records!inner(conversation_id)")
+    .eq("records.conversation_id", conversationId);
+
+  if (error) {
+    throw error;
+  }
+
+  return (data as Pick<AttachmentRow, "file_path">[]).map(
+    (row) => row.file_path,
+  );
+}
+
 export async function getAttachmentsByType(
   client: SupabaseClient<Database>,
   userId: string,

--- a/src/repositories/storageService.test.ts
+++ b/src/repositories/storageService.test.ts
@@ -4,6 +4,7 @@ import type { Database } from "@/types/database";
 import {
   buildParticipantThumbnailPath,
   buildStoragePath,
+  isOwnedStoragePath,
   uploadFile,
   getFileUrl,
   getFileUrls,
@@ -56,6 +57,26 @@ describe("storageService", () => {
       });
 
       expect(path).toBe("user-1/participants/participant-1/photo.jpg");
+    });
+  });
+
+  describe("isOwnedStoragePath", () => {
+    it("returns true when the path is prefixed with the user id", () => {
+      expect(
+        isOwnedStoragePath("user-1", "user-1/conv-1/rec-1/photo.jpg"),
+      ).toBe(true);
+    });
+
+    it("returns false when the path belongs to another user", () => {
+      expect(
+        isOwnedStoragePath("user-1", "user-2/conv-1/rec-1/photo.jpg"),
+      ).toBe(false);
+    });
+
+    it("returns false when the path merely starts with the user id as a substring", () => {
+      expect(
+        isOwnedStoragePath("user-1", "user-12/conv-1/rec-1/photo.jpg"),
+      ).toBe(false);
     });
   });
 

--- a/src/repositories/storageService.test.ts
+++ b/src/repositories/storageService.test.ts
@@ -297,5 +297,62 @@ describe("storageService", () => {
         deleteFiles(client, ["user-1/conv-1/rec-1/photo.jpg"]),
       ).rejects.toEqual(storageError);
     });
+
+    function buildPaths(count: number): string[] {
+      return Array.from(
+        { length: count },
+        (_, i) => `user-1/conv-1/rec-1/file-${i}.jpg`,
+      );
+    }
+
+    it("calls remove once when paths are exactly the batch size", async () => {
+      const remove = vi.fn().mockResolvedValue({ data: [], error: null });
+      const client = createMockStorageClient({ remove });
+
+      const paths = buildPaths(1000);
+      await expect(deleteFiles(client, paths)).resolves.toBeUndefined();
+
+      expect(remove).toHaveBeenCalledTimes(1);
+      expect(remove).toHaveBeenNthCalledWith(1, paths);
+    });
+
+    it("splits into two chunks when paths exceed the batch size by one", async () => {
+      const remove = vi.fn().mockResolvedValue({ data: [], error: null });
+      const client = createMockStorageClient({ remove });
+
+      const paths = buildPaths(1001);
+      await expect(deleteFiles(client, paths)).resolves.toBeUndefined();
+
+      expect(remove).toHaveBeenCalledTimes(2);
+      expect(remove).toHaveBeenNthCalledWith(1, paths.slice(0, 1000));
+      expect(remove).toHaveBeenNthCalledWith(2, paths.slice(1000, 1001));
+    });
+
+    it("splits into multiple chunks and calls remove sequentially in order", async () => {
+      const remove = vi.fn().mockResolvedValue({ data: [], error: null });
+      const client = createMockStorageClient({ remove });
+
+      const paths = buildPaths(2500);
+      await expect(deleteFiles(client, paths)).resolves.toBeUndefined();
+
+      expect(remove).toHaveBeenCalledTimes(3);
+      expect(remove).toHaveBeenNthCalledWith(1, paths.slice(0, 1000));
+      expect(remove).toHaveBeenNthCalledWith(2, paths.slice(1000, 2000));
+      expect(remove).toHaveBeenNthCalledWith(3, paths.slice(2000, 2500));
+    });
+
+    it("throws when a later chunk fails, without processing further chunks", async () => {
+      const storageError = { message: "Bulk delete failed", statusCode: "500" };
+      const remove = vi
+        .fn()
+        .mockResolvedValueOnce({ data: [], error: null })
+        .mockResolvedValueOnce({ data: null, error: storageError });
+      const client = createMockStorageClient({ remove });
+
+      const paths = buildPaths(2500);
+      await expect(deleteFiles(client, paths)).rejects.toEqual(storageError);
+
+      expect(remove).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/src/repositories/storageService.ts
+++ b/src/repositories/storageService.ts
@@ -6,6 +6,9 @@ const BUCKET_NAME = "media";
 /** Signed URL の有効期限（秒） */
 const SIGNED_URL_EXPIRY_SECONDS = 3600;
 
+/** Supabase Storage の remove が1回に受け付けるオブジェクト数の上限 */
+const STORAGE_REMOVE_BATCH_SIZE = 1000;
+
 type SignedUrlBatchItem = {
   error: string | null;
   path: string | null;
@@ -162,6 +165,8 @@ export async function deleteFile(
 
 /**
  * 複数ファイルを Storage から一括削除する
+ * Supabase Storage の remove は1回あたり STORAGE_REMOVE_BATCH_SIZE 件までのため、
+ * 上限件数ごとにチャンク分割して順番に削除する
  */
 export async function deleteFiles(
   client: SupabaseClient<Database>,
@@ -171,9 +176,12 @@ export async function deleteFiles(
     return;
   }
 
-  const { error } = await client.storage.from(BUCKET_NAME).remove(paths);
+  for (let i = 0; i < paths.length; i += STORAGE_REMOVE_BATCH_SIZE) {
+    const chunk = paths.slice(i, i + STORAGE_REMOVE_BATCH_SIZE);
+    const { error } = await client.storage.from(BUCKET_NAME).remove(chunk);
 
-  if (error) {
-    throw error;
+    if (error) {
+      throw error;
+    }
   }
 }

--- a/src/repositories/storageService.ts
+++ b/src/repositories/storageService.ts
@@ -59,6 +59,14 @@ export function isStorageFilePath(path: string | null): path is string {
 }
 
 /**
+ * Storage パスが指定ユーザーの所有物か判定する
+ * 規約: {userId}/... で始まるパスのみそのユーザーの所有物とみなす
+ */
+export function isOwnedStoragePath(userId: string, path: string): boolean {
+  return path.startsWith(`${userId}/`);
+}
+
+/**
  * ファイルを Supabase Storage にアップロードする
  */
 export async function uploadFile(

--- a/src/usecases/conversationUseCases.test.ts
+++ b/src/usecases/conversationUseCases.test.ts
@@ -26,11 +26,13 @@ import {
   validateUpdateConversationInput,
   validateParticipantsPreserveExisting,
 } from "./conversationUseCases";
+import { StorageCleanupError } from "./storageCleanupError";
 
 vi.mock("@/repositories/conversationRepository");
 vi.mock("@/repositories/conversationActivePeriodRepository");
 vi.mock("@/repositories/conversationParticipantRepository");
 vi.mock("@/repositories/recordRepository");
+vi.mock("@/repositories/attachmentRepository");
 vi.mock("@/repositories/storageService", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("@/repositories/storageService")>();
@@ -38,6 +40,7 @@ vi.mock("@/repositories/storageService", async (importOriginal) => {
     ...actual,
     getFileUrls: vi.fn(),
     uploadFile: vi.fn(),
+    deleteFiles: vi.fn(),
   };
 });
 
@@ -58,7 +61,8 @@ import {
   updateConversationParticipantThumbnail,
 } from "@/repositories/conversationParticipantRepository";
 import { getRecordsByConversation } from "@/repositories/recordRepository";
-import { getFileUrls, uploadFile } from "@/repositories/storageService";
+import { getAttachmentFilePathsByConversation } from "@/repositories/attachmentRepository";
+import { getFileUrls, uploadFile, deleteFiles } from "@/repositories/storageService";
 
 const mockGetConversations = vi.mocked(getConversations);
 const mockGetConversation = vi.mocked(getConversation);
@@ -85,6 +89,10 @@ const mockUpdateConversationParticipantThumbnail = vi.mocked(
 const mockGetRecordsByConversation = vi.mocked(getRecordsByConversation);
 const mockGetFileUrls = vi.mocked(getFileUrls);
 const mockUploadFile = vi.mocked(uploadFile);
+const mockDeleteFiles = vi.mocked(deleteFiles);
+const mockGetAttachmentFilePathsByConversation = vi.mocked(
+  getAttachmentFilePathsByConversation,
+);
 
 const client = {} as SupabaseClient<Database>;
 
@@ -592,10 +600,97 @@ describe("conversationUseCases", () => {
   });
 
   describe("deleteExistingConversation", () => {
-    it("deletes conversation via repository", async () => {
+    it("deletes conversation and owned storage files gathered from attachments, cover, and thumbnails in one deleteFiles call", async () => {
+      mockGetAttachmentFilePathsByConversation.mockResolvedValue([
+        "user-1/conv-1/rec-1/photo.jpg",
+      ]);
+      mockGetConversation.mockResolvedValue({
+        ...baseConversation,
+        coverImagePath: "user-1/conversations/conv-1/cover/cover.jpg",
+      });
+      mockGetConversationParticipants.mockResolvedValue([
+        {
+          ...participants[0],
+          thumbnailPath: "user-1/participants/participant-1/photo.jpg",
+        },
+      ]);
+      mockDeleteConversation.mockResolvedValue(undefined);
+      mockDeleteFiles.mockResolvedValue(undefined);
+
+      await deleteExistingConversation(client, "conv-1", "user-1");
+
+      expect(mockDeleteConversation).toHaveBeenCalledWith(client, "conv-1");
+      expect(mockDeleteFiles).toHaveBeenCalledTimes(1);
+      const deletedPaths = mockDeleteFiles.mock.calls[0][1];
+      expect(new Set(deletedPaths)).toEqual(
+        new Set([
+          "user-1/conv-1/rec-1/photo.jpg",
+          "user-1/conversations/conv-1/cover/cover.jpg",
+          "user-1/participants/participant-1/photo.jpg",
+        ]),
+      );
+    });
+
+    it("deduplicates paths when the cover image reuses a participant thumbnail path", async () => {
+      mockGetAttachmentFilePathsByConversation.mockResolvedValue([]);
+      mockGetConversation.mockResolvedValue({
+        ...baseConversation,
+        coverImagePath: "user-1/participants/participant-1/photo.jpg",
+      });
+      mockGetConversationParticipants.mockResolvedValue([
+        {
+          ...participants[0],
+          thumbnailPath: "user-1/participants/participant-1/photo.jpg",
+        },
+      ]);
+      mockDeleteConversation.mockResolvedValue(undefined);
+      mockDeleteFiles.mockResolvedValue(undefined);
+
+      await deleteExistingConversation(client, "conv-1", "user-1");
+
+      expect(mockDeleteFiles).toHaveBeenCalledWith(client, [
+        "user-1/participants/participant-1/photo.jpg",
+      ]);
+    });
+
+    it("deletes conversation without calling deleteFiles when there are no storage paths", async () => {
+      mockGetAttachmentFilePathsByConversation.mockResolvedValue([]);
+      mockGetConversation.mockResolvedValue(baseConversation);
+      mockGetConversationParticipants.mockResolvedValue(participants);
       mockDeleteConversation.mockResolvedValue(undefined);
 
-      await deleteExistingConversation(client, "conv-1");
+      await deleteExistingConversation(client, "conv-1", "user-1");
+
+      expect(mockDeleteConversation).toHaveBeenCalledWith(client, "conv-1");
+      expect(mockDeleteFiles).not.toHaveBeenCalled();
+    });
+
+    it("excludes another user's storage paths from deletion", async () => {
+      mockGetAttachmentFilePathsByConversation.mockResolvedValue([
+        "user-2/conv-1/rec-1/photo.jpg",
+      ]);
+      mockGetConversation.mockResolvedValue(baseConversation);
+      mockGetConversationParticipants.mockResolvedValue(participants);
+      mockDeleteConversation.mockResolvedValue(undefined);
+
+      await deleteExistingConversation(client, "conv-1", "user-1");
+
+      expect(mockDeleteConversation).toHaveBeenCalledWith(client, "conv-1");
+      expect(mockDeleteFiles).not.toHaveBeenCalled();
+    });
+
+    it("deletes the conversation and throws StorageCleanupError when deleteFiles fails", async () => {
+      mockGetAttachmentFilePathsByConversation.mockResolvedValue([
+        "user-1/conv-1/rec-1/photo.jpg",
+      ]);
+      mockGetConversation.mockResolvedValue(baseConversation);
+      mockGetConversationParticipants.mockResolvedValue(participants);
+      mockDeleteConversation.mockResolvedValue(undefined);
+      mockDeleteFiles.mockRejectedValue(new Error("Storage error"));
+
+      await expect(
+        deleteExistingConversation(client, "conv-1", "user-1"),
+      ).rejects.toThrow(StorageCleanupError);
 
       expect(mockDeleteConversation).toHaveBeenCalledWith(client, "conv-1");
     });

--- a/src/usecases/conversationUseCases.ts
+++ b/src/usecases/conversationUseCases.ts
@@ -22,14 +22,18 @@ import {
 import { getConversationParticipants } from "@/repositories/conversationParticipantRepository";
 import { updateConversationParticipantThumbnail } from "@/repositories/conversationParticipantRepository";
 import { getRecordsByConversation } from "@/repositories/recordRepository";
+import { getAttachmentFilePathsByConversation } from "@/repositories/attachmentRepository";
 import { MAX_PARTICIPANT_NAME_LENGTH } from "@/lib/validationConstraints";
 import {
   buildConversationCoverPath,
   buildParticipantThumbnailPath,
+  deleteFiles,
   getFileUrls,
+  isOwnedStoragePath,
   isStorageFilePath,
   uploadFile,
 } from "@/repositories/storageService";
+import { StorageCleanupError } from "./storageCleanupError";
 
 export type ConversationSummary = Conversation & {
   activeDays: number;
@@ -481,8 +485,47 @@ export async function updateExistingConversation(
 export async function deleteExistingConversation(
   client: SupabaseClient<Database>,
   id: string,
+  userId: string,
 ): Promise<void> {
-  return deleteConversation(client, id);
+  const [attachmentFilePaths, conversation, participants] = await Promise.all([
+    getAttachmentFilePathsByConversation(client, id),
+    getConversation(client, id),
+    getConversationParticipants(client, id),
+  ]);
+
+  const candidatePaths = new Set<string>(attachmentFilePaths);
+  if (conversation?.coverImagePath) {
+    candidatePaths.add(conversation.coverImagePath);
+  }
+  for (const participant of participants) {
+    if (participant.thumbnailPath) {
+      candidatePaths.add(participant.thumbnailPath);
+    }
+  }
+
+  const filePaths = [...candidatePaths].filter(
+    (filePath) =>
+      isStorageFilePath(filePath) && isOwnedStoragePath(userId, filePath),
+  );
+
+  await deleteConversation(client, id);
+
+  if (filePaths.length === 0) {
+    return;
+  }
+
+  try {
+    await deleteFiles(client, filePaths);
+  } catch (error) {
+    console.error("Failed to delete storage files for conversation", {
+      conversationId: id,
+      filePaths,
+      error,
+    });
+    throw new StorageCleanupError(
+      `会話（${id}）のDB削除は完了しましたが、Storageファイルの削除に失敗しました`,
+    );
+  }
 }
 
 export async function getConversationCoverUrls(

--- a/src/usecases/recordUseCases.test.ts
+++ b/src/usecases/recordUseCases.test.ts
@@ -23,6 +23,7 @@ import {
   attachRecordMedia,
   getMediaDisplayInfoForRecords,
 } from "./recordUseCases";
+import { StorageCleanupError } from "./storageCleanupError";
 
 vi.mock("@/repositories/recordRepository");
 vi.mock("@/repositories/attachmentRepository");
@@ -47,6 +48,9 @@ import {
   uploadFile,
   getFileUrls,
   deleteFile,
+  deleteFiles,
+  isStorageFilePath,
+  isOwnedStoragePath,
 } from "@/repositories/storageService";
 
 const mockCreateTextRecordAtNextPosition = vi.mocked(
@@ -68,6 +72,9 @@ const mockBuildStoragePath = vi.mocked(buildStoragePath);
 const mockUploadFile = vi.mocked(uploadFile);
 const mockGetFileUrls = vi.mocked(getFileUrls);
 const mockDeleteFile = vi.mocked(deleteFile);
+const mockDeleteFiles = vi.mocked(deleteFiles);
+const mockIsStorageFilePath = vi.mocked(isStorageFilePath);
+const mockIsOwnedStoragePath = vi.mocked(isOwnedStoragePath);
 const mockGetRecordsByConversationAndDateRange = vi.mocked(
   getRecordsByConversationAndDateRange,
 );
@@ -347,10 +354,85 @@ describe("recordUseCases", () => {
   });
 
   describe("deleteExistingRecord", () => {
-    it("deletes record via repository", async () => {
+    it("deletes DB row and owned storage files for an attached record", async () => {
+      mockGetAttachmentsByRecord.mockResolvedValue([
+        {
+          id: "att-1",
+          recordId: "rec-1",
+          filePath: "user-1/conv-1/rec-1/photo.jpg",
+          mimeType: "image/jpeg",
+          fileSize: 100,
+          createdAt: "2026-01-01T00:00:00Z",
+        },
+      ]);
+      mockIsStorageFilePath.mockReturnValue(true);
+      mockIsOwnedStoragePath.mockReturnValue(true);
+      mockDeleteRecord.mockResolvedValue(undefined);
+      mockDeleteFiles.mockResolvedValue(undefined);
+
+      await deleteExistingRecord(client, "rec-1", "user-1");
+
+      expect(mockGetAttachmentsByRecord).toHaveBeenCalledWith(client, "rec-1");
+      expect(mockDeleteRecord).toHaveBeenCalledWith(client, "rec-1");
+      expect(mockDeleteFiles).toHaveBeenCalledWith(client, [
+        "user-1/conv-1/rec-1/photo.jpg",
+      ]);
+    });
+
+    it("deletes DB row without calling deleteFiles for a text record without attachments", async () => {
+      mockGetAttachmentsByRecord.mockResolvedValue([]);
       mockDeleteRecord.mockResolvedValue(undefined);
 
-      await deleteExistingRecord(client, "rec-1");
+      await deleteExistingRecord(client, "rec-1", "user-1");
+
+      expect(mockDeleteRecord).toHaveBeenCalledWith(client, "rec-1");
+      expect(mockDeleteFiles).not.toHaveBeenCalled();
+    });
+
+    it("excludes another user's storage paths from deletion", async () => {
+      mockGetAttachmentsByRecord.mockResolvedValue([
+        {
+          id: "att-1",
+          recordId: "rec-1",
+          filePath: "user-2/conv-1/rec-1/photo.jpg",
+          mimeType: "image/jpeg",
+          fileSize: 100,
+          createdAt: "2026-01-01T00:00:00Z",
+        },
+      ]);
+      mockIsStorageFilePath.mockReturnValue(true);
+      mockIsOwnedStoragePath.mockReturnValue(false);
+      mockDeleteRecord.mockResolvedValue(undefined);
+
+      await deleteExistingRecord(client, "rec-1", "user-1");
+
+      expect(mockIsOwnedStoragePath).toHaveBeenCalledWith(
+        "user-1",
+        "user-2/conv-1/rec-1/photo.jpg",
+      );
+      expect(mockDeleteRecord).toHaveBeenCalledWith(client, "rec-1");
+      expect(mockDeleteFiles).not.toHaveBeenCalled();
+    });
+
+    it("deletes the DB row and throws StorageCleanupError when deleteFiles fails", async () => {
+      mockGetAttachmentsByRecord.mockResolvedValue([
+        {
+          id: "att-1",
+          recordId: "rec-1",
+          filePath: "user-1/conv-1/rec-1/photo.jpg",
+          mimeType: "image/jpeg",
+          fileSize: 100,
+          createdAt: "2026-01-01T00:00:00Z",
+        },
+      ]);
+      mockIsStorageFilePath.mockReturnValue(true);
+      mockIsOwnedStoragePath.mockReturnValue(true);
+      mockDeleteRecord.mockResolvedValue(undefined);
+      mockDeleteFiles.mockRejectedValue(new Error("Storage error"));
+
+      await expect(
+        deleteExistingRecord(client, "rec-1", "user-1"),
+      ).rejects.toThrow(StorageCleanupError);
 
       expect(mockDeleteRecord).toHaveBeenCalledWith(client, "rec-1");
     });

--- a/src/usecases/recordUseCases.ts
+++ b/src/usecases/recordUseCases.ts
@@ -20,7 +20,11 @@ import {
   uploadFile,
   getFileUrls,
   deleteFile,
+  deleteFiles,
+  isStorageFilePath,
+  isOwnedStoragePath,
 } from "@/repositories/storageService";
+import { StorageCleanupError } from "./storageCleanupError";
 
 export type AddTextRecordInput = {
   conversationId: string;
@@ -164,8 +168,34 @@ export async function updateExistingRecord(
 export async function deleteExistingRecord(
   client: SupabaseClient<Database>,
   id: string,
+  userId: string,
 ): Promise<void> {
-  return deleteRecord(client, id);
+  const attachments = await getAttachmentsByRecord(client, id);
+  const filePaths = attachments
+    .map((attachment) => attachment.filePath)
+    .filter(
+      (filePath) =>
+        isStorageFilePath(filePath) && isOwnedStoragePath(userId, filePath),
+    );
+
+  await deleteRecord(client, id);
+
+  if (filePaths.length === 0) {
+    return;
+  }
+
+  try {
+    await deleteFiles(client, filePaths);
+  } catch (error) {
+    console.error("Failed to delete storage files for record", {
+      recordId: id,
+      filePaths,
+      error,
+    });
+    throw new StorageCleanupError(
+      `レコード（${id}）のDB削除は完了しましたが、Storageファイルの削除に失敗しました`,
+    );
+  }
 }
 
 // --- メディアレコード ---

--- a/src/usecases/storageCleanupError.ts
+++ b/src/usecases/storageCleanupError.ts
@@ -1,0 +1,5 @@
+/**
+ * レコード・トーク削除時に DB 行の削除は成功したが Storage ファイルの削除に失敗したことを表すエラー
+ * recordUseCases / conversationUseCases の双方から使うため専用ファイルに切り出している
+ */
+export class StorageCleanupError extends Error {}


### PR DESCRIPTION
## Why / Background
- レコード削除・トーク削除で DB 行（`attachments` は `ON DELETE CASCADE`）は消えるが、Supabase Storage のオブジェクトは削除されず孤立ファイルとして蓄積していた（#135）
- .eml インポートの再取込を繰り返すと、参照元のない画像が Storage に残り続ける

## What / Summary
- レコードを削除すると、そのレコードに紐づく Storage ファイル（画像・動画・音声）も削除される
- トークを削除すると、配下の添付メディア・カバー画像・参加者サムネイルが Storage からまとめて削除される
- Storage 削除の対象は認証ユーザー所有のパス（`{userId}/...`）に限定する
- Storage 削除に失敗した場合、成功扱いで無言終了せず「削除は完了したがメディアファイルの削除に失敗した」旨をトーストで通知する

## Scope / Impact
- 影響する画面・API・データ：レコード削除（チャット/カード）、トーク削除、Supabase Storage（`media` バケット）
- 影響しないもの：テキストレコード・未添付メディアレコードの削除挙動（従来どおり／Storage API は呼ばない）、参加者単体のサムネイル差し替え
- 破壊的変更（Breaking change）：なし
  - `deleteExistingRecord` / `deleteExistingConversation` に `userId` 引数が増えたが、呼び出し元は Server Actions のみで追随済み

## Related Issues
- Closes #135
- Related #113 #115 #129 #132

## DB / Migration（DB変更があるときだけ）
- 変更なし（Storage 削除は Storage API 経由。SQL は追加していない）

## Test Plan
- [x] 自動テスト（内容：）
  - `deleteExistingRecord`：添付済みレコードで DB 削除 + `deleteFiles` が正しいパスで呼ばれる／テキスト・未添付レコードでは `deleteFiles` を呼ばない／他ユーザーのパスを削除対象から除外する／`deleteFiles` 失敗時に DB 削除済みのまま `StorageCleanupError` を投げる
  - `deleteExistingConversation`：attachment・カバー画像・参加者サムネイルのパスを重複排除して 1 回の `deleteFiles` に渡す／対象パスが無ければ `deleteFiles` を呼ばない／他ユーザーのパスを除外する／`deleteFiles` 失敗時に `StorageCleanupError`
  - `getAttachmentFilePathsByConversation`：`records!inner` 経由の単一クエリ（N+1 なし）
  - `isOwnedStoragePath`：プレフィックス一致・別ユーザー・部分一致（`user-10` が `user-1` に誤マッチしない）
  - Server Actions：`StorageCleanupError` 時にレコード削除は `revalidatePath` の上で警告を返す／トーク削除は `redirect` せず警告を返す
  - `pnpm typecheck` / `pnpm lint` / `pnpm test`（77 files / 848 tests）/ `pnpm build` すべて通過
- [ ] 手動確認（未実施。理由：実データ（本番 Supabase）での削除確認はマージ後に実施予定。画像レコード削除・トーク削除後に Storage 画面でファイルが消えることを確認する）

## Screenshots (UI changes only)
- UI 変更なし（エラートーストの文言追加のみ）

## Review Notes（レビュワー向け）
- 見てほしい点（優先順に）：
  1. 削除順序（DB → Storage、Issue の案A）と部分失敗時の扱い。Storage 削除失敗時は DB 削除済みのため `StorageCleanupError` を投げ、action 層で「削除は完了したが Storage 削除に失敗」として通知している（トーク削除ではリダイレクトしない）
  2. 削除対象パスの絞り込み。`isStorageFilePath` + `isOwnedStoragePath({userId}/ 前方一致)` の二段で他ユーザー・外部URLを除外している
  3. トーク削除時のパス収集。attachment は `records!inner` の単一クエリ、カバー画像と参加者サムネイルは同一パスになりうるため `Set` で重複排除している
- 不安な点 / 判断が欲しい点：
  - `StorageCleanupError` を `src/usecases/storageCleanupError.ts` に単独ファイルとして置いた（`AttachMediaError` は `recordUseCases.ts` 内に定義）。record / conversation の双方から使うため、どちらかの usecase に置くと usecase 間の依存が生まれるのを避けた
- 既知の制限 / 今後やること：
  - 既に発生済みの孤立ファイルの一括削除は本 PR の対象外（Issue #135 の Non-goals）。確認用クエリは Issue 本文に記載済み
  - Storage と DB は分散トランザクションではないため、Storage 削除失敗時は孤立ファイルが残る（ログに失敗パスを構造化出力している）

## Checklist
- [x] `.env*` や秘密情報を含まない
- [x] 例外系（空/NULL/境界値）を考慮した（添付0件、カバー画像なし、サムネイルなし、外部URL、別ユーザーのパス）
- [x] 影響範囲に対してテスト項目が十分
- [x] 破壊的変更がある場合、移行手順を記載した（破壊的変更なし）

---
🤖 Generated with Claude Code / ✅ Human-checked: @kikun-dev
